### PR TITLE
ToSchema class with Generic deriving and other helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+Unreleased changes
+---
+* Remove `Swagger`/`swagger` prefixes;
+* Add `ToSchema` type class with default generic implementation;
+* Add configurable generic `ToSchema` helpers;
+* Add `doctest` test suite;
+* Fixes:
+    * Fix `HasSchemaCommon` instance for `Schema`;
+    * Change `minimum`, `maximum` and `multipleOf` properties to be any number,
+      not necessarily an integer.
+
 0.3
 ---
 * Fixes:

--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -6,6 +6,8 @@
 -- and Swagger-Codegen to generate clients in various languages.
 -- Additional utilities can also take advantage of the resulting files, such as testing tools.
 module Data.Swagger (
+  module Data.Swagger.Schema,
+
   -- * Swagger specification
   Swagger(..),
   Host(..),
@@ -78,6 +80,8 @@ module Data.Swagger (
   MimeList(..),
   URL(..),
 ) where
+
+import Data.Swagger.Schema
 
 import Data.Swagger.Internal
 

--- a/src/Data/Swagger/Generic.hs
+++ b/src/Data/Swagger/Generic.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+module Data.Swagger.Generic where
+
+import Control.Lens
+import Data.Aeson
+import Data.Monoid
+import Data.Proxy
+import qualified Data.Text as Text
+import GHC.Generics
+
+import Data.Swagger
+import Data.Swagger.Lens
+
+class ToSchema a where
+  toSchema :: proxy a -> Schema
+  default toSchema :: (Generic a, GToSchema (Rep a)) => proxy a -> Schema
+  toSchema = genericToSchema
+
+class GToSchema (f :: * -> *) where
+  gtoSchema :: proxy f -> Schema -> Schema
+
+instance {-# OVERLAPPABLE #-} ToSchema a => ToSchema [a] where
+  toSchema _ = mempty
+    { _schemaType = SchemaArray
+    , _schemaItems = Just (SchemaItemsObject (Inline (toSchema (Proxy :: Proxy a))))
+    }
+
+instance {-# OVERLAPPING #-} ToSchema String where
+  toSchema _ = mempty { _schemaType = SchemaString }
+
+instance ToSchema Bool where
+  toSchema _ = mempty { _schemaType = SchemaBoolean }
+
+instance ToSchema Integer where
+  toSchema _ = mempty { _schemaType = SchemaInteger }
+
+instance ToSchema Int where toSchema = toSchemaBoundedIntegral
+
+instance ToSchema Double where
+  toSchema _ = mempty { _schemaType = SchemaNumber }
+
+toSchemaBoundedIntegral :: forall a proxy. (Bounded a, Integral a) => proxy a -> Schema
+toSchemaBoundedIntegral _ = mempty
+  & schemaType .~ SchemaInteger
+  & schemaMinimum ?~ toInteger (minBound :: a)
+  & schemaMaximum ?~ toInteger (maxBound :: a)
+
+toSchemaBoundedEnum :: forall a proxy. (ToJSON a, Bounded a, Enum a) => proxy a -> Schema
+toSchemaBoundedEnum _ = mempty
+  & schemaType .~ SchemaString
+  & schemaEnum ?~ map toJSON [minBound..maxBound :: a]
+
+genericToSchema :: forall a proxy. (Generic a, GToSchema (Rep a)) => proxy a -> Schema
+genericToSchema _ = gtoSchema (Proxy :: Proxy (Rep a)) mempty
+
+instance (GToSchema f, GToSchema g) => GToSchema (f :*: g) where
+  gtoSchema _ = gtoSchema (Proxy :: Proxy f) <> gtoSchema (Proxy :: Proxy g)
+
+-- | Single constructor data types.
+instance GToSchema f => GToSchema (D1 d (C1 c f)) where
+  gtoSchema _ = gtoSchema (Proxy :: Proxy f)
+
+-- | Record fields.
+instance (Selector s, GToSchema f) => GToSchema (S1 s f) where
+  gtoSchema _ = schemaProperties . at fieldName ?~ Inline fieldSchema
+    where
+      fieldName = Text.pack (selName (undefined :: S1 s f p))
+      fieldSchema = gtoSchema (Proxy :: Proxy f) mempty
+
+instance ToSchema c => GToSchema (K1 i c) where
+  gtoSchema _ _ = toSchema (Proxy :: Proxy c)
+

--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -19,6 +19,7 @@ import qualified Data.HashMap.Strict      as HashMap
 import           Data.Map                 (Map)
 import qualified Data.Map                 as Map
 import           Data.Monoid
+import           Data.Scientific          (Scientific)
 import           Data.String              (fromString)
 import           Data.Text                (Text)
 import qualified Data.Text                as Text
@@ -420,9 +421,9 @@ data SchemaCommon = SchemaCommon
     -- Unlike JSON Schema this value MUST conform to the defined type for this parameter.
     _schemaCommonDefault :: Maybe Value
 
-  , _schemaCommonMaximum :: Maybe Integer
+  , _schemaCommonMaximum :: Maybe Scientific
   , _schemaCommonExclusiveMaximum :: Maybe Bool
-  , _schemaCommonMinimum :: Maybe Integer
+  , _schemaCommonMinimum :: Maybe Scientific
   , _schemaCommonExclusiveMinimum :: Maybe Bool
   , _schemaCommonMaxLength :: Maybe Integer
   , _schemaCommonMinLength :: Maybe Integer
@@ -431,7 +432,7 @@ data SchemaCommon = SchemaCommon
   , _schemaCommonMinItems :: Maybe Integer
   , _schemaCommonUniqueItems :: Maybe Bool
   , _schemaCommonEnum :: Maybe [Value]
-  , _schemaCommonMultipleOf :: Maybe Integer
+  , _schemaCommonMultipleOf :: Maybe Scientific
   } deriving (Eq, Show, Generic)
 
 data Xml = Xml

--- a/src/Data/Swagger/Internal/Utils.hs
+++ b/src/Data/Swagger/Internal/Utils.hs
@@ -36,6 +36,7 @@ jsonPrefix prefix = defaultOptions
   { fieldLabelModifier      = modifier . drop 1
   , constructorTagModifier  = modifier
   , sumEncoding             = ObjectWithSingleField
+  , omitNothingFields       = True
   }
   where
     modifier = lowerFirstUppers . drop (length prefix)

--- a/src/Data/Swagger/Lens.hs
+++ b/src/Data/Swagger/Lens.hs
@@ -60,7 +60,7 @@ instance HasDescription ExternalDocs   (Maybe Text) where description = external
 class HasSchemaCommon s where
   schemaCommon :: Lens' s SchemaCommon
 
-instance HasSchemaCommon Schema where schemaCommon = schemaCommon
+instance HasSchemaCommon Schema where schemaCommon = schemaSchemaCommon
 instance HasSchemaCommon ParameterOtherSchema where schemaCommon = parameterOtherSchemaCommon
 instance HasSchemaCommon Items where schemaCommon = itemsCommon
 instance HasSchemaCommon Header where schemaCommon = headerCommon

--- a/src/Data/Swagger/Lens.hs
+++ b/src/Data/Swagger/Lens.hs
@@ -7,6 +7,7 @@ module Data.Swagger.Lens where
 import Control.Lens
 import Control.Lens.TH
 import Data.Aeson (Value)
+import Data.Scientific (Scientific)
 import Data.Swagger.Internal
 import Data.Text (Text)
 
@@ -69,13 +70,13 @@ instance HasSchemaCommon SchemaCommon where schemaCommon = id
 schemaDefault :: HasSchemaCommon s => Lens' s (Maybe Value)
 schemaDefault = schemaCommon.schemaCommonDefault
 
-schemaMaximum :: HasSchemaCommon s => Lens' s (Maybe Integer)
+schemaMaximum :: HasSchemaCommon s => Lens' s (Maybe Scientific)
 schemaMaximum = schemaCommon.schemaCommonMaximum
 
 schemaExclusiveMaximum :: HasSchemaCommon s => Lens' s (Maybe Bool)
 schemaExclusiveMaximum = schemaCommon.schemaCommonExclusiveMaximum
 
-schemaMinimum :: HasSchemaCommon s => Lens' s (Maybe Integer)
+schemaMinimum :: HasSchemaCommon s => Lens' s (Maybe Scientific)
 schemaMinimum = schemaCommon.schemaCommonMinimum
 
 schemaExclusiveMinimum :: HasSchemaCommon s => Lens' s (Maybe Bool)
@@ -102,6 +103,6 @@ schemaUniqueItems = schemaCommon.schemaCommonUniqueItems
 schemaEnum :: HasSchemaCommon s => Lens' s (Maybe [Value])
 schemaEnum = schemaCommon.schemaCommonEnum
 
-schemaMultipleOf :: HasSchemaCommon s => Lens' s (Maybe Integer)
+schemaMultipleOf :: HasSchemaCommon s => Lens' s (Maybe Scientific)
 schemaMultipleOf = schemaCommon.schemaCommonMultipleOf
 

--- a/src/Data/Swagger/Schema.hs
+++ b/src/Data/Swagger/Schema.hs
@@ -1,0 +1,8 @@
+module Data.Swagger.Schema (
+  ToSchema(..),
+  toSchemaBoundedIntegral,
+  toSchemaBoundedEnum,
+  genericToSchema,
+) where
+
+import Data.Swagger.Schema.Internal

--- a/src/Data/Swagger/Schema.hs
+++ b/src/Data/Swagger/Schema.hs
@@ -10,11 +10,9 @@ module Data.Swagger.Schema (
 
   genericToSchema,
   genericToNamedSchema,
-  genericToNamedSchemaBoundedEnum,
   genericToNamedSchemaBoundedIntegral,
 
   toSchemaBoundedIntegral,
-  toSchemaBoundedEnum,
 ) where
 
 import Data.Swagger.Schema.Internal

--- a/src/Data/Swagger/Schema.hs
+++ b/src/Data/Swagger/Schema.hs
@@ -1,5 +1,6 @@
 module Data.Swagger.Schema (
   ToSchema(..),
+  NamedSchema,
   toSchema,
   toSchemaRef,
   schemaName,

--- a/src/Data/Swagger/Schema.hs
+++ b/src/Data/Swagger/Schema.hs
@@ -1,18 +1,28 @@
+-- |
+-- Module:      Data.Swagger.Schema
+-- Copyright:   (c) 2015 GetShopTV
+-- License:     BSD3
+-- Maintainer:  Nickolay Kudasov <nickolay@getshoptv.com>
+-- Stability:   experimental
+--
+-- Types and functions for working with Swagger schema.
 module Data.Swagger.Schema (
+  -- * Encoding
   ToSchema(..),
   NamedSchema,
   toSchema,
   toSchemaRef,
   schemaName,
 
-  SchemaOptions(..),
-  defaultSchemaOptions,
-
+  -- * Generic schema encoding
   genericToSchema,
   genericToNamedSchema,
   genericToNamedSchemaBoundedIntegral,
-
   toSchemaBoundedIntegral,
+
+  -- * Generic encoding configuration
+  SchemaOptions(..),
+  defaultSchemaOptions,
 ) where
 
 import Data.Swagger.Schema.Internal

--- a/src/Data/Swagger/Schema.hs
+++ b/src/Data/Swagger/Schema.hs
@@ -2,6 +2,8 @@ module Data.Swagger.Schema (
   ToSchema(..),
   toSchemaBoundedIntegral,
   toSchemaBoundedEnum,
+  SchemaOptions(..),
+  defaultSchemaOptions,
   genericToSchema,
 ) where
 

--- a/src/Data/Swagger/Schema.hs
+++ b/src/Data/Swagger/Schema.hs
@@ -11,6 +11,7 @@ module Data.Swagger.Schema (
   genericToSchema,
   genericToNamedSchema,
   genericToNamedSchemaBoundedEnum,
+  genericToNamedSchemaBoundedIntegral,
 
   toSchemaBoundedIntegral,
   toSchemaBoundedEnum,

--- a/src/Data/Swagger/Schema.hs
+++ b/src/Data/Swagger/Schema.hs
@@ -1,6 +1,8 @@
 module Data.Swagger.Schema (
-  toSchema,
   ToSchema(..),
+  toSchema,
+  toSchemaRef,
+  schemaName,
 
   SchemaOptions(..),
   defaultSchemaOptions,

--- a/src/Data/Swagger/Schema.hs
+++ b/src/Data/Swagger/Schema.hs
@@ -1,10 +1,16 @@
 module Data.Swagger.Schema (
+  toSchema,
   ToSchema(..),
-  toSchemaBoundedIntegral,
-  toSchemaBoundedEnum,
+
   SchemaOptions(..),
   defaultSchemaOptions,
+
   genericToSchema,
+  genericToNamedSchema,
+  genericToNamedSchemaBoundedEnum,
+
+  toSchemaBoundedIntegral,
+  toSchemaBoundedEnum,
 ) where
 
 import Data.Swagger.Schema.Internal

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -159,11 +159,19 @@ toSchemaBoundedEnum _ = mempty
   & schemaType .~ SchemaString
   & schemaEnum ?~ map toJSON [minBound..maxBound :: a]
 
+genericToNamedSchemaBoundedIntegral :: forall a d f proxy.
+  ( Bounded a, Integral a
+  , Generic a, Rep a ~ D1 d f, Datatype d)
+  => SchemaOptions -> proxy a -> NamedSchema
+genericToNamedSchemaBoundedIntegral opts proxy
+  = (gdatatypeSchemaName opts (Proxy :: Proxy d), toSchemaBoundedIntegral proxy)
+
 genericToNamedSchemaBoundedEnum :: forall a d f proxy.
   ( ToJSON a, Bounded a, Enum a
   , Generic a, Rep a ~ D1 d f, Datatype d)
   => SchemaOptions -> proxy a -> NamedSchema
-genericToNamedSchemaBoundedEnum opts proxy = (gdatatypeSchemaName opts (Proxy :: Proxy d), toSchemaBoundedEnum proxy)
+genericToNamedSchemaBoundedEnum opts proxy
+  = (gdatatypeSchemaName opts (Proxy :: Proxy d), toSchemaBoundedEnum proxy)
 
 genericToSchema :: (Generic a, GToSchema (Rep a)) => SchemaOptions -> proxy a -> Schema
 genericToSchema opts = snd . genericToNamedSchema opts

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -151,8 +151,8 @@ defaultSchemaOptions = SchemaOptions
 toSchemaBoundedIntegral :: forall a proxy. (Bounded a, Integral a) => proxy a -> Schema
 toSchemaBoundedIntegral _ = mempty
   & schemaType .~ SchemaInteger
-  & schemaMinimum ?~ toInteger (minBound :: a)
-  & schemaMaximum ?~ toInteger (maxBound :: a)
+  & schemaMinimum ?~ fromInteger (toInteger (minBound :: a))
+  & schemaMaximum ?~ fromInteger (toInteger (maxBound :: a))
 
 toSchemaBoundedEnum :: forall a proxy. (ToJSON a, Bounded a, Enum a) => proxy a -> Schema
 toSchemaBoundedEnum _ = mempty

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -9,9 +9,13 @@ module Data.Swagger.Schema.Internal where
 
 import Control.Lens
 import Data.Aeson
+import Data.HashMap.Strict (HashMap)
+import Data.HashSet (HashSet)
 import Data.Int
+import Data.Map (Map)
 import Data.Monoid
 import Data.Proxy
+import Data.Set (Set)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import Data.Word
@@ -76,6 +80,24 @@ instance ToSchema T.Text where
 
 instance ToSchema TL.Text where
   toSchema _ = toSchema (Proxy :: Proxy String)
+
+instance ToSchema a => ToSchema (Map String a) where
+  toSchema _ = mempty
+    & schemaType  .~ SchemaObject
+    & schemaAdditionalProperties ?~ toSchema (Proxy :: Proxy a)
+
+instance ToSchema a => ToSchema (Map T.Text  a) where toSchema _ = toSchema (Proxy :: Proxy (Map String a))
+instance ToSchema a => ToSchema (Map TL.Text a) where toSchema _ = toSchema (Proxy :: Proxy (Map String a))
+
+instance ToSchema a => ToSchema (HashMap String  a) where toSchema _ = toSchema (Proxy :: Proxy (Map String a))
+instance ToSchema a => ToSchema (HashMap T.Text  a) where toSchema _ = toSchema (Proxy :: Proxy (Map String a))
+instance ToSchema a => ToSchema (HashMap TL.Text a) where toSchema _ = toSchema (Proxy :: Proxy (Map String a))
+
+instance ToSchema a => ToSchema (Set a) where
+  toSchema _ = toSchema (Proxy :: Proxy [a])
+    & schemaUniqueItems ?~ True
+
+instance ToSchema a => ToSchema (HashSet a) where toSchema _ = toSchema (Proxy :: Proxy (Set a))
 
 toSchemaBoundedIntegral :: forall a proxy. (Bounded a, Integral a) => proxy a -> Schema
 toSchemaBoundedIntegral _ = mempty

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -57,6 +57,9 @@ instance ToSchema Word64 where toSchema = toSchemaBoundedIntegral
 instance ToSchema Double where
   toSchema _ = mempty { _schemaType = SchemaNumber }
 
+instance ToSchema Float where
+  toSchema _ = mempty { _schemaType = SchemaNumber }
+
 instance ToSchema a => ToSchema (Maybe a) where
   toSchema _ = toSchema (Proxy :: Proxy a)
 

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -34,18 +34,17 @@ class GToSchema (f :: * -> *) where
 
 instance {-# OVERLAPPABLE #-} ToSchema a => ToSchema [a] where
   toSchema _ = mempty
-    { _schemaType = SchemaArray
-    , _schemaItems = Just (SchemaItemsObject (Inline (toSchema (Proxy :: Proxy a))))
-    }
+    & schemaType  .~ SchemaArray
+    & schemaItems ?~ SchemaItemsObject (Inline (toSchema (Proxy :: Proxy a)))
 
 instance {-# OVERLAPPING #-} ToSchema String where
-  toSchema _ = mempty { _schemaType = SchemaString }
+  toSchema _ = mempty & schemaType .~ SchemaString
 
 instance ToSchema Bool where
-  toSchema _ = mempty { _schemaType = SchemaBoolean }
+  toSchema _ = mempty & schemaType .~ SchemaBoolean
 
 instance ToSchema Integer where
-  toSchema _ = mempty { _schemaType = SchemaInteger }
+  toSchema _ = mempty & schemaType .~ SchemaInteger
 
 instance ToSchema Int    where toSchema = toSchemaBoundedIntegral
 instance ToSchema Int8   where toSchema = toSchemaBoundedIntegral
@@ -60,10 +59,10 @@ instance ToSchema Word32 where toSchema = toSchemaBoundedIntegral
 instance ToSchema Word64 where toSchema = toSchemaBoundedIntegral
 
 instance ToSchema Double where
-  toSchema _ = mempty { _schemaType = SchemaNumber }
+  toSchema _ = mempty & schemaType .~ SchemaNumber
 
 instance ToSchema Float where
-  toSchema _ = mempty { _schemaType = SchemaNumber }
+  toSchema _ = mempty & schemaType .~ SchemaNumber
 
 instance ToSchema a => ToSchema (Maybe a) where
   toSchema _ = toSchema (Proxy :: Proxy a)

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -201,14 +201,14 @@ instance {-# OVERLAPPABLE #-} GToSchema f => GToSchema (C1 c f) where
 -- | Single field constructor.
 instance (Selector s, GToSchema f) => GToSchema (C1 c (S1 s f)) where
   gtoNamedSchema opts _ s
-    | unwrapUnaryRecords opts = unnamed fieldSchema
-    | otherwise = unnamed $
+    | unwrapUnaryRecords opts = unnamed (snd fieldSchema)
+    | otherwise =
         case schema ^. schemaItems of
           Just (SchemaItemsArray [_]) -> fieldSchema
-          _ -> schema
+          _ -> unnamed schema
     where
       schema      = gtoSchema opts (Proxy :: Proxy (S1 s f)) s
-      fieldSchema = gtoSchema opts (Proxy :: Proxy f) s
+      fieldSchema = gtoNamedSchema opts (Proxy :: Proxy f) s
 
 gtoSchemaRef :: GToSchema f => SchemaOptions -> proxy f -> Referenced Schema
 gtoSchemaRef opts proxy = case gtoNamedSchema opts proxy mempty of

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -135,6 +135,7 @@ instance ToSchema a => ToSchema (Dual a)    where toNamedSchema _ = unnamed $ to
 
 data SchemaOptions = SchemaOptions
   { fieldLabelModifier :: String -> String
+  , constructorTagModifier :: String -> String
   , datatypeNameModifier :: String -> String
   , useReferences :: Bool
   , unwrapUnaryRecords :: Bool
@@ -143,6 +144,7 @@ data SchemaOptions = SchemaOptions
 defaultSchemaOptions :: SchemaOptions
 defaultSchemaOptions = SchemaOptions
   { fieldLabelModifier = id
+  , constructorTagModifier = id
   , datatypeNameModifier = id
   , useReferences = True
   , unwrapUnaryRecords = False
@@ -262,7 +264,7 @@ gsumConToSchema tagSchemaRef opts _ schema = schema
   & schemaMaxProperties ?~ 1
   & schemaMinProperties ?~ 1
   where
-    tag = T.pack (conName (Proxy3 :: Proxy3 c f p))
+    tag = T.pack (constructorTagModifier opts (conName (Proxy3 :: Proxy3 c f p)))
 
 instance {-# OVERLAPPABLE #-} (Constructor c, GToSchema f) => GSumToSchema (C1 c f) where
   gsumToSchema opts = gsumConToSchema tagSchemaRef opts

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -289,7 +289,7 @@ instance {-# OVERLAPPABLE #-} GToSchema f => GToSchema (C1 c f) where
 -- | Single field constructor.
 instance (Selector s, GToSchema f) => GToSchema (C1 c (S1 s f)) where
   gtoNamedSchema opts _ s
-    | unwrapUnaryRecords opts = unnamed (snd fieldSchema)
+    | unwrapUnaryRecords opts = fieldSchema
     | otherwise =
         case schema ^. schemaItems of
           Just (SchemaItemsArray [_]) -> fieldSchema

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -132,6 +132,12 @@ instance ToSchema Word16 where toNamedSchema = unnamed . toSchemaBoundedIntegral
 instance ToSchema Word32 where toNamedSchema = unnamed . toSchemaBoundedIntegral
 instance ToSchema Word64 where toNamedSchema = unnamed . toSchemaBoundedIntegral
 
+instance ToSchema Char where
+  toNamedSchema _ = unnamed $ mempty
+    & schemaType .~ SchemaString
+    & schemaMaxLength ?~ 1
+    & schemaMinLength ?~ 1
+
 instance ToSchema Double where
   toNamedSchema _ = unnamed $ mempty & schemaType .~ SchemaNumber
 
@@ -140,6 +146,8 @@ instance ToSchema Float where
 
 instance ToSchema a => ToSchema (Maybe a) where
   toNamedSchema _ = unnamed $ toSchema (Proxy :: Proxy a)
+
+instance (ToSchema a, ToSchema b) => ToSchema (Either a b)
 
 instance ToSchema ()
 instance (ToSchema a, ToSchema b) => ToSchema (a, b)

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -99,6 +99,14 @@ instance ToSchema a => ToSchema (Set a) where
 
 instance ToSchema a => ToSchema (HashSet a) where toSchema _ = toSchema (Proxy :: Proxy (Set a))
 
+instance ToSchema All where toSchema _ = toSchema (Proxy :: Proxy Bool)
+instance ToSchema Any where toSchema _ = toSchema (Proxy :: Proxy Bool)
+instance ToSchema a => ToSchema (Sum a)     where toSchema _ = toSchema (Proxy :: Proxy a)
+instance ToSchema a => ToSchema (Product a) where toSchema _ = toSchema (Proxy :: Proxy a)
+instance ToSchema a => ToSchema (First a)   where toSchema _ = toSchema (Proxy :: Proxy a)
+instance ToSchema a => ToSchema (Last a)    where toSchema _ = toSchema (Proxy :: Proxy a)
+instance ToSchema a => ToSchema (Dual a)    where toSchema _ = toSchema (Proxy :: Proxy a)
+
 toSchemaBoundedIntegral :: forall a proxy. (Bounded a, Integral a) => proxy a -> Schema
 toSchemaBoundedIntegral _ = mempty
   & schemaType .~ SchemaInteger

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
@@ -149,7 +150,7 @@ instance {-# OVERLAPPING #-} (Selector s, ToSchema c) => GToSchema (S1 s (K1 i (
         & schemaType .~ SchemaObject
         & schemaProperties . at fieldName ?~ Inline fieldSchema
     where
-      fieldName = T.pack (fieldLabelModifier opts (selName (undefined :: S1 s f p)))
+      fieldName = T.pack (fieldLabelModifier opts (selName (Proxy3 :: Proxy3 s f p)))
       fieldSchema = toSchema (Proxy :: Proxy c)
 
 -- | Record fields.
@@ -163,9 +164,11 @@ instance {-# OVERLAPPABLE #-} (Selector s, GToSchema f) => GToSchema (S1 s f) wh
         & schemaProperties . at fieldName ?~ Inline fieldSchema
         & schemaRequired %~ (fieldName :)
     where
-      fieldName = T.pack (fieldLabelModifier opts (selName (undefined :: S1 s f p)))
+      fieldName = T.pack (fieldLabelModifier opts (selName (Proxy3 :: Proxy3 s f p)))
       fieldSchema = gtoSchema opts (Proxy :: Proxy f) mempty
 
 instance ToSchema c => GToSchema (K1 i c) where
   gtoSchema _ _ _ = toSchema (Proxy :: Proxy c)
+
+data Proxy3 a b c = Proxy3
 

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -135,6 +135,7 @@ instance ToSchema a => ToSchema (Dual a)    where toNamedSchema _ = unnamed $ to
 data SchemaOptions = SchemaOptions
   { fieldLabelModifier :: String -> String
   , datatypeNameModifier :: String -> String
+  , useReferences :: Bool
   , unwrapUnaryRecords :: Bool
   }
 
@@ -142,6 +143,7 @@ defaultSchemaOptions :: SchemaOptions
 defaultSchemaOptions = SchemaOptions
   { fieldLabelModifier = id
   , datatypeNameModifier = id
+  , useReferences = True
   , unwrapUnaryRecords = False
   }
 
@@ -196,7 +198,8 @@ instance (Datatype d, Selector s, GToSchema f) => GToSchema (D1 d (C1 c (S1 s f)
 
 gtoSchemaRef :: GToSchema f => SchemaOptions -> proxy f -> Referenced Schema
 gtoSchemaRef opts proxy = case gtoNamedSchema opts proxy mempty of
-  (Just name, _)  -> Ref (Reference ("#/definitions/" <> T.pack name))
+  (Just name, _)
+    | useReferences opts -> Ref (Reference ("#/definitions/" <> T.pack name))
   (_, schema)     -> Inline schema
 
 appendItem :: Referenced Schema -> Maybe SchemaItems -> Maybe SchemaItems

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-module Data.Swagger.Generic where
+module Data.Swagger.Schema.Internal where
 
 import Control.Lens
 import Data.Aeson
@@ -14,7 +14,7 @@ import Data.Proxy
 import qualified Data.Text as Text
 import GHC.Generics
 
-import Data.Swagger
+import Data.Swagger.Internal
 import Data.Swagger.Lens
 
 class ToSchema a where

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -17,9 +17,12 @@ import Data.Char
 import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
 import Data.Int
+import Data.IntSet (IntSet)
+import Data.IntMap (IntMap)
 import Data.Map (Map)
 import Data.Monoid
 import Data.Proxy
+import Data.Scientific (Scientific)
 import Data.Set (Set)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
@@ -138,6 +141,9 @@ instance ToSchema Char where
     & schemaMaxLength ?~ 1
     & schemaMinLength ?~ 1
 
+instance ToSchema Scientific where
+  toNamedSchema _ = unnamed $ mempty & schemaType .~ SchemaNumber
+
 instance ToSchema Double where
   toNamedSchema _ = unnamed $ mempty & schemaType .~ SchemaNumber
 
@@ -162,6 +168,12 @@ instance ToSchema T.Text where
 
 instance ToSchema TL.Text where
   toNamedSchema _ = unnamed $ toSchema (Proxy :: Proxy String)
+
+instance ToSchema IntSet where toNamedSchema _ = toNamedSchema (Proxy :: Proxy (Set Int))
+
+-- | NOTE: This schema does not account for the uniqueness of keys.
+instance ToSchema a => ToSchema (IntMap a) where
+  toNamedSchema _ = toNamedSchema (Proxy :: Proxy [(Int, a)])
 
 instance ToSchema a => ToSchema (Map String a) where
   toNamedSchema _ = unnamed $ mempty

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -138,6 +138,7 @@ data SchemaOptions = SchemaOptions
   { fieldLabelModifier :: String -> String
   , constructorTagModifier :: String -> String
   , datatypeNameModifier :: String -> String
+  , allNullaryToStringTag :: Bool
   , useReferences :: Bool
   , unwrapUnaryRecords :: Bool
   }
@@ -147,6 +148,7 @@ defaultSchemaOptions = SchemaOptions
   { fieldLabelModifier = id
   , constructorTagModifier = id
   , datatypeNameModifier = id
+  , allNullaryToStringTag = True
   , useReferences = True
   , unwrapUnaryRecords = False
   }
@@ -247,7 +249,7 @@ instance ToSchema c => GToSchema (K1 i c) where
 
 instance (GSumToSchema f, GSumToSchema g) => GToSchema (f :+: g) where
   gtoNamedSchema opts _ s
-    | allNullary = unnamed (toStringTag sumSchema)
+    | allNullaryToStringTag opts && allNullary = unnamed (toStringTag sumSchema)
     | otherwise = unnamed sumSchema
     where
       (All allNullary, sumSchema) = gsumToSchema opts (Proxy :: Proxy (f :+: g)) s

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -9,9 +9,11 @@ module Data.Swagger.Schema.Internal where
 
 import Control.Lens
 import Data.Aeson
+import Data.Int
 import Data.Monoid
 import Data.Proxy
 import qualified Data.Text as Text
+import Data.Word
 import GHC.Generics
 
 import Data.Swagger.Internal
@@ -40,7 +42,17 @@ instance ToSchema Bool where
 instance ToSchema Integer where
   toSchema _ = mempty { _schemaType = SchemaInteger }
 
-instance ToSchema Int where toSchema = toSchemaBoundedIntegral
+instance ToSchema Int    where toSchema = toSchemaBoundedIntegral
+instance ToSchema Int8   where toSchema = toSchemaBoundedIntegral
+instance ToSchema Int16  where toSchema = toSchemaBoundedIntegral
+instance ToSchema Int32  where toSchema = toSchemaBoundedIntegral
+instance ToSchema Int64  where toSchema = toSchemaBoundedIntegral
+
+instance ToSchema Word   where toSchema = toSchemaBoundedIntegral
+instance ToSchema Word8  where toSchema = toSchemaBoundedIntegral
+instance ToSchema Word16 where toSchema = toSchemaBoundedIntegral
+instance ToSchema Word32 where toSchema = toSchemaBoundedIntegral
+instance ToSchema Word64 where toSchema = toSchemaBoundedIntegral
 
 instance ToSchema Double where
   toSchema _ = mempty { _schemaType = SchemaNumber }

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -94,6 +94,7 @@ instance ToSchema Float where
 instance ToSchema a => ToSchema (Maybe a) where
   toNamedSchema _ = unnamed $ toSchema (Proxy :: Proxy a)
 
+instance ToSchema ()
 instance (ToSchema a, ToSchema b) => ToSchema (a, b)
 instance (ToSchema a, ToSchema b, ToSchema c) => ToSchema (a, b, c)
 instance (ToSchema a, ToSchema b, ToSchema c, ToSchema d) => ToSchema (a, b, c, d)
@@ -187,6 +188,14 @@ gdatatypeSchemaName opts _ = case name of
   _ -> Nothing
   where
     name = datatypeNameModifier opts (datatypeName (Proxy3 :: Proxy3 d f a))
+
+nullarySchema :: Schema
+nullarySchema = mempty
+  & schemaType .~ SchemaArray
+  & schemaEnum ?~ [ toJSON () ]
+
+instance GToSchema U1 where
+  gtoNamedSchema _ _ _ = unnamed nullarySchema
 
 instance (GToSchema f, GToSchema g) => GToSchema (f :*: g) where
   gtoNamedSchema opts _ = unnamed . gtoSchema opts (Proxy :: Proxy f) . gtoSchema opts (Proxy :: Proxy g)

--- a/src/Data/Swagger/Schema/Internal.hs
+++ b/src/Data/Swagger/Schema/Internal.hs
@@ -63,6 +63,13 @@ instance ToSchema Float where
 instance ToSchema a => ToSchema (Maybe a) where
   toSchema _ = toSchema (Proxy :: Proxy a)
 
+instance (ToSchema a, ToSchema b) => ToSchema (a, b)
+instance (ToSchema a, ToSchema b, ToSchema c) => ToSchema (a, b, c)
+instance (ToSchema a, ToSchema b, ToSchema c, ToSchema d) => ToSchema (a, b, c, d)
+instance (ToSchema a, ToSchema b, ToSchema c, ToSchema d, ToSchema e) => ToSchema (a, b, c, d, e)
+instance (ToSchema a, ToSchema b, ToSchema c, ToSchema d, ToSchema e, ToSchema f) => ToSchema (a, b, c, d, e, f)
+instance (ToSchema a, ToSchema b, ToSchema c, ToSchema d, ToSchema e, ToSchema f, ToSchema g) => ToSchema (a, b, c, d, e, f, g)
+
 toSchemaBoundedIntegral :: forall a proxy. (Bounded a, Integral a) => proxy a -> Schema
 toSchemaBoundedIntegral _ = mempty
   & schemaType .~ SchemaInteger

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -54,7 +54,9 @@ test-suite spec
                   , unordered-containers
                   , vector
   other-modules:
+    SpecCommon
     Data.SwaggerSpec
+    Data.Swagger.SchemaSpec
   default-language: Haskell2010
 
 source-repository head

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -35,6 +35,7 @@ library
                      , network
                      , template-haskell
                      , text
+                     , time
                      , unordered-containers
                      , lens
                      , scientific

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -37,6 +37,7 @@ library
                      , text
                      , unordered-containers
                      , lens
+                     , scientific
   default-language:    Haskell2010
 
 test-suite spec

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -62,6 +62,13 @@ test-suite spec
     Data.Swagger.SchemaSpec
   default-language: Haskell2010
 
+test-suite doctest
+  build-depends:    base, doctest, Glob
+  default-language: Haskell2010
+  hs-source-dirs:   test
+  main-is:          DocTest.hs
+  type:             exitcode-stdio-1.0
+
 source-repository head
   type:     git
   location: https://github.com/GetShopTV/swagger2.git

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -20,6 +20,7 @@ library
   hs-source-dirs:      src
   exposed-modules:
     Data.Swagger
+    Data.Swagger.Generic
     Data.Swagger.Lens
 
     -- internal modules

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -52,6 +52,7 @@ test-suite spec
                   , text
                   , aeson
                   , aeson-qq
+                  , containers
                   , unordered-containers
                   , vector
   other-modules:

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -20,12 +20,13 @@ library
   hs-source-dirs:      src
   exposed-modules:
     Data.Swagger
-    Data.Swagger.Generic
     Data.Swagger.Lens
+    Data.Swagger.Schema
 
     -- internal modules
     Data.Swagger.Internal
     Data.Swagger.Internal.Utils
+    Data.Swagger.Schema.Internal
   build-depends:       base == 4.*
                      , aeson
                      , containers

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -48,8 +48,6 @@ spec = do
       context "String" $ checkSchemaName Nothing (Proxy :: Proxy String)
       context "(Int, Float)" $ checkSchemaName Nothing (Proxy :: Proxy (Int, Float))
       context "Person" $ checkSchemaName (Just "Person") (Proxy :: Proxy Person)
-  describe "toSchemaBoundedEnum" $ do
-    context "Color" $ checkToSchema (Proxy :: Proxy Color) colorSchemaJSON
 
 main :: IO ()
 main = hspec spec
@@ -122,16 +120,13 @@ pointSchemaJSON = [aesonQQ|
 
 
 -- ========================================================================
--- Color (bounded enum)
+-- Color (enum)
 -- ========================================================================
 data Color
   = Red
   | Green
   | Blue
-  deriving (Generic, Enum, Bounded, ToJSON)
-
-instance ToSchema Color where
-  toNamedSchema = genericToNamedSchemaBoundedEnum defaultSchemaOptions
+  deriving (Generic, ToSchema)
 
 colorSchemaJSON :: Value
 colorSchemaJSON = [aesonQQ|

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -9,6 +9,7 @@ import Data.Aeson
 import Data.Aeson.QQ
 import Data.Char
 import Data.Proxy
+import Data.Set (Set)
 import GHC.Generics
 
 import Data.Swagger
@@ -33,6 +34,7 @@ spec = do
     context "Point (fieldLabelModifier)" $ checkToSchema (Proxy :: Proxy Point) pointSchemaJSON
     context "Color (bounded enum)" $ checkToSchema (Proxy :: Proxy Color) colorSchemaJSON
     context "Paint (record with bounded enum field)" $ checkToSchema (Proxy :: Proxy Paint) paintSchemaJSON
+    context "UserGroup (set newtype)" $ checkToSchema (Proxy :: Proxy UserGroup) userGroupSchemaJSON
     context "Unary records" $ do
       context "Email (unwrapUnaryRecords)"  $ checkToSchema (Proxy :: Proxy Email)  emailSchemaJSON
       context "UserId (non-record newtype)" $ checkToSchema (Proxy :: Proxy UserId) userIdSchemaJSON
@@ -181,12 +183,28 @@ emailSchemaJSON = [aesonQQ|
 -- ========================================================================
 
 newtype UserId = UserId Integer
-  deriving (Generic, ToSchema)
+  deriving (Eq, Ord, Generic, ToSchema)
 
 userIdSchemaJSON :: Value
 userIdSchemaJSON = [aesonQQ|
 {
   "type": "integer"
+}
+|]
+
+-- ========================================================================
+-- UserGroup (set newtype)
+-- ========================================================================
+
+newtype UserGroup = UserGroup (Set UserId)
+  deriving (Generic, ToSchema)
+
+userGroupSchemaJSON :: Value
+userGroupSchemaJSON = [aesonQQ|
+{
+  "type": "array",
+  "items": { "$ref": "#/definitions/UserId" },
+  "uniqueItems": true
 }
 |]
 

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -6,10 +6,13 @@ module Data.Swagger.SchemaSpec where
 
 import Data.Aeson
 import Data.Aeson.QQ
+import Data.Char
 import Data.Proxy
 import GHC.Generics
 
 import Data.Swagger
+import Data.Swagger.Schema
+
 import SpecCommon
 import Test.Hspec
 
@@ -21,6 +24,7 @@ spec = do
   describe "Generic ToSchema" $ do
     context "Person" $ checkToSchema (Proxy :: Proxy Person) personSchemaJSON
     context "ISPair" $ checkToSchema (Proxy :: Proxy ISPair) ispairSchemaJSON
+    context "Point (custom fieldLabelModifier)" $ checkToSchema (Proxy :: Proxy Point) pointSchemaJSON
 
 main :: IO ()
 main = hspec spec
@@ -57,6 +61,28 @@ ispairSchemaJSON = [aesonQQ|
       { "type": "integer" },
       { "type": "string"  }
     ]
+}
+|]
+
+data Point = Point
+  { pointX :: Double
+  , pointY :: Double
+  } deriving (Generic)
+
+instance ToSchema Point where
+  toSchema = genericToSchema defaultSchemaOptions
+    { fieldLabelModifier = map toLower . drop (length "point") }
+
+pointSchemaJSON :: Value
+pointSchemaJSON = [aesonQQ|
+{
+  "type": "object",
+  "properties":
+    {
+      "x": { "type": "number" },
+      "y": { "type": "number" }
+    },
+  "required": ["x", "y"]
 }
 |]
 

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -31,6 +31,8 @@ spec = do
     context "Person" $ checkToSchema (Proxy :: Proxy Person) personSchemaJSON
     context "ISPair" $ checkToSchema (Proxy :: Proxy ISPair) ispairSchemaJSON
     context "Point (fieldLabelModifier)" $ checkToSchema (Proxy :: Proxy Point) pointSchemaJSON
+    context "Color (bounded enum)" $ checkToSchema (Proxy :: Proxy Color) colorSchemaJSON
+    context "Paint (record with bounded enum field)" $ checkToSchema (Proxy :: Proxy Paint) paintSchemaJSON
     context "Unary records" $ do
       context "Email (unwrapUnaryRecords)"  $ checkToSchema (Proxy :: Proxy Email)  emailSchemaJSON
       context "UserId (non-record newtype)" $ checkToSchema (Proxy :: Proxy UserId) userIdSchemaJSON
@@ -115,7 +117,7 @@ pointSchemaJSON = [aesonQQ|
 
 
 -- ========================================================================
--- Point (record data type with custom fieldLabelModifier)
+-- Color (bounded enum)
 -- ========================================================================
 data Color
   = Red
@@ -124,13 +126,35 @@ data Color
   deriving (Generic, Enum, Bounded, ToJSON)
 
 instance ToSchema Color where
-  toNamedSchema = genericToNamedSchemaBoundedEnum
+  toNamedSchema = genericToNamedSchemaBoundedEnum defaultSchemaOptions
 
 colorSchemaJSON :: Value
 colorSchemaJSON = [aesonQQ|
 {
   "type": "string",
   "enum": ["Red", "Green", "Blue"]
+}
+|]
+
+-- ========================================================================
+-- Paint (record with bounded enum property)
+-- ========================================================================
+
+newtype Paint = Paint { color :: Color }
+  deriving (Generic, ToSchema)
+
+paintSchemaJSON :: Value
+paintSchemaJSON = [aesonQQ|
+{
+  "type": "object",
+  "properties":
+    {
+      "color":
+        {
+          "$ref": "#/definitions/Color"
+        }
+    },
+  "required": ["color"]
 }
 |]
 

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -29,6 +29,7 @@ checkSchemaName name proxy =
 spec :: Spec
 spec = do
   describe "Generic ToSchema" $ do
+    context "Unit" $ checkToSchema (Proxy :: Proxy Unit) unitSchemaJSON
     context "Person" $ checkToSchema (Proxy :: Proxy Person) personSchemaJSON
     context "ISPair" $ checkToSchema (Proxy :: Proxy ISPair) ispairSchemaJSON
     context "Point (fieldLabelModifier)" $ checkToSchema (Proxy :: Proxy Point) pointSchemaJSON
@@ -321,6 +322,20 @@ statusSchemaJSON = [aesonQQ|
     },
   "maxProperties": 1,
   "minProperties": 1
+}
+|]
+
+-- ========================================================================
+-- Unit type
+-- ========================================================================
+
+data Unit = Unit deriving (Generic, ToSchema)
+
+unitSchemaJSON :: Value
+unitSchemaJSON = [aesonQQ|
+{
+  "type": "array",
+  "enum": [[]]
 }
 |]
 

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -25,10 +25,15 @@ spec = do
     context "Person" $ checkToSchema (Proxy :: Proxy Person) personSchemaJSON
     context "ISPair" $ checkToSchema (Proxy :: Proxy ISPair) ispairSchemaJSON
     context "Point (custom fieldLabelModifier)" $ checkToSchema (Proxy :: Proxy Point) pointSchemaJSON
+  describe "toSchemaBoundedEnum" $ do
+    context "Color" $ checkToSchema (Proxy :: Proxy Color) colorSchemaJSON
 
 main :: IO ()
 main = hspec spec
 
+-- ========================================================================
+-- Person (simple record with optional fields)
+-- ========================================================================
 data Person = Person
   { name  :: String
   , phone :: Integer
@@ -49,6 +54,9 @@ personSchemaJSON = [aesonQQ|
 }
 |]
 
+-- ========================================================================
+-- ISPair (non-record product data type)
+-- ========================================================================
 data ISPair = ISPair Integer String
   deriving (Generic, ToSchema)
 
@@ -64,6 +72,9 @@ ispairSchemaJSON = [aesonQQ|
 }
 |]
 
+-- ========================================================================
+-- Point (record data type with custom fieldLabelModifier)
+-- ========================================================================
 data Point = Point
   { pointX :: Double
   , pointY :: Double
@@ -83,6 +94,27 @@ pointSchemaJSON = [aesonQQ|
       "y": { "type": "number" }
     },
   "required": ["x", "y"]
+}
+|]
+
+
+-- ========================================================================
+-- Point (record data type with custom fieldLabelModifier)
+-- ========================================================================
+data Color
+  = Red
+  | Green
+  | Blue
+  deriving (Generic, Enum, Bounded, ToJSON)
+
+instance ToSchema Color where
+  toSchema = toSchemaBoundedEnum
+
+colorSchemaJSON :: Value
+colorSchemaJSON = [aesonQQ|
+{
+  "type": "string",
+  "enum": ["Red", "Green", "Blue"]
 }
 |]
 

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -45,6 +45,7 @@ spec = do
     context "Sum types" $ do
       context "Status (sum of unary constructors)" $ checkToSchema (Proxy :: Proxy Status) statusSchemaJSON
       context "Character (ref and record sum)" $ checkToSchema (Proxy :: Proxy Character) characterSchemaJSON
+      context "Light (sum with unwrapUnaryRecords)" $ checkToSchema (Proxy :: Proxy Light) lightSchemaJSON
     context "Schema name" $ do
       context "String" $ checkSchemaName Nothing (Proxy :: Proxy String)
       context "(Int, Float)" $ checkSchemaName Nothing (Proxy :: Proxy (Int, Float))
@@ -367,3 +368,33 @@ characterSchemaJSON = [aesonQQ|
   "minProperties": 1
 }
 |]
+
+-- ========================================================================
+-- Light (sum type with unwrapUnaryRecords)
+-- ========================================================================
+
+data Light
+  = LightFreq Double
+  | LightColor Color
+  | LightWaveLength { waveLength :: Double }
+  deriving (Generic)
+
+instance ToSchema Light where
+  toNamedSchema = genericToNamedSchema defaultSchemaOptions
+    { unwrapUnaryRecords = True }
+
+lightSchemaJSON :: Value
+lightSchemaJSON = [aesonQQ|
+{
+  "type": "object",
+  "properties":
+    {
+      "LightFreq": { "type": "number" },
+      "LightColor": { "$ref": "#/definitions/Color" },
+      "LightWaveLength": { "type": "number" }
+    },
+  "maxProperties": 1,
+  "minProperties": 1
+}
+|]
+

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+module Data.Swagger.SchemaSpec where
+
+import Data.Aeson
+import Data.Aeson.QQ
+import Data.Proxy
+import GHC.Generics
+
+import Data.Swagger
+import SpecCommon
+import Test.Hspec
+
+checkToSchema :: ToSchema a => Proxy a -> Value -> Spec
+checkToSchema proxy js = toSchema proxy <~> js
+
+spec :: Spec
+spec = do
+  describe "Generic ToSchema" $
+    context "Person" $ checkToSchema (Proxy :: Proxy Person) personSchemaJSON
+
+main :: IO ()
+main = hspec spec
+
+data Person = Person
+  { name  :: String
+  , phone :: Integer
+  , email :: Maybe String
+  } deriving (Generic, ToSchema)
+
+personSchemaJSON :: Value
+personSchemaJSON = [aesonQQ|
+{
+  "type": "object",
+  "properties":
+    {
+      "name":   { "type": "string"  },
+      "phone":  { "type": "integer" },
+      "email":  { "type": "string"  }
+    },
+  "required": ["name", "phone"]
+}
+|]

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -36,6 +36,7 @@ spec = do
       context "UserId (non-record newtype)" $ checkToSchema (Proxy :: Proxy UserId) userIdSchemaJSON
       context "Player (unary record)" $ checkToSchema (Proxy :: Proxy Player) playerSchemaJSON
     context "Players (inlining schema)" $ checkToSchema (Proxy :: Proxy Players) playersSchemaJSON
+    context "MyRoseTree (datatypeNameModifier)" $ checkToSchema (Proxy :: Proxy MyRoseTree) myRoseTreeSchemaJSON
     context "Schema name" $ do
       context "String" $ checkSchemaName Nothing (Proxy :: Proxy String)
       context "(Int, Float)" $ checkSchemaName Nothing (Proxy :: Proxy (Int, Float))
@@ -185,6 +186,39 @@ playerSchemaJSON = [aesonQQ|
         }
     },
   "required": ["position"]
+}
+|]
+
+-- ========================================================================
+-- MyRoseTree (custom datatypeNameModifier)
+-- ========================================================================
+
+data MyRoseTree = MyRoseTree
+  { root  :: String
+  , trees :: [MyRoseTree]
+  } deriving (Generic)
+
+instance ToSchema MyRoseTree where
+  toNamedSchema = genericToNamedSchema defaultSchemaOptions
+    { datatypeNameModifier = drop (length "My") }
+
+myRoseTreeSchemaJSON :: Value
+myRoseTreeSchemaJSON = [aesonQQ|
+{
+  "type": "object",
+  "properties":
+    {
+      "root": { "type": "string" },
+      "trees":
+        {
+          "type": "array",
+          "items":
+            {
+              "$ref": "#/definitions/RoseTree"
+            }
+        }
+    },
+  "required": ["root", "trees"]
 }
 |]
 

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -41,6 +41,8 @@ spec = do
       context "Player (unary record)" $ checkToSchema (Proxy :: Proxy Player) playerSchemaJSON
     context "Players (inlining schema)" $ checkToSchema (Proxy :: Proxy Players) playersSchemaJSON
     context "MyRoseTree (datatypeNameModifier)" $ checkToSchema (Proxy :: Proxy MyRoseTree) myRoseTreeSchemaJSON
+    context "Sum types" $ do
+      context "Status (sum of unary constructors)" $ checkToSchema (Proxy :: Proxy Status) statusSchemaJSON
     context "Schema name" $ do
       context "String" $ checkSchemaName Nothing (Proxy :: Proxy String)
       context "(Int, Float)" $ checkSchemaName Nothing (Proxy :: Proxy (Int, Float))
@@ -292,6 +294,29 @@ playersSchemaJSON = [aesonQQ|
         },
       "required": ["position"]
     }
+}
+|]
+
+-- ========================================================================
+-- Status (sum type with unary constructors)
+-- ========================================================================
+
+data Status
+  = StatusOk String
+  | StatusError String
+  deriving (Generic, ToSchema)
+
+statusSchemaJSON :: Value
+statusSchemaJSON = [aesonQQ|
+{
+  "type": "object",
+  "properties":
+    {
+      "StatusOk": { "type": "string" },
+      "StatusError": { "type": "string" }
+    },
+  "maxProperties": 1,
+  "minProperties": 1
 }
 |]
 

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -24,7 +24,11 @@ spec = do
   describe "Generic ToSchema" $ do
     context "Person" $ checkToSchema (Proxy :: Proxy Person) personSchemaJSON
     context "ISPair" $ checkToSchema (Proxy :: Proxy ISPair) ispairSchemaJSON
-    context "Point (custom fieldLabelModifier)" $ checkToSchema (Proxy :: Proxy Point) pointSchemaJSON
+    context "Point (fieldLabelModifier)" $ checkToSchema (Proxy :: Proxy Point) pointSchemaJSON
+    context "Unary records" $ do
+      context "Email (unwrapUnaryRecords)"  $ checkToSchema (Proxy :: Proxy Email)  emailSchemaJSON
+      context "UserId (non-record newtype)" $ checkToSchema (Proxy :: Proxy UserId) userIdSchemaJSON
+      context "Player (unary record)" $ checkToSchema (Proxy :: Proxy Player) playerSchemaJSON
   describe "toSchemaBoundedEnum" $ do
     context "Color" $ checkToSchema (Proxy :: Proxy Color) colorSchemaJSON
 
@@ -118,3 +122,63 @@ colorSchemaJSON = [aesonQQ|
 }
 |]
 
+-- ========================================================================
+-- Email (newtype with unwrapUnaryRecords set to True)
+-- ========================================================================
+
+newtype Email = Email { getEmail :: String }
+  deriving (Generic)
+
+instance ToSchema Email where
+  toSchema = genericToSchema defaultSchemaOptions
+    { unwrapUnaryRecords = True }
+
+emailSchemaJSON :: Value
+emailSchemaJSON = [aesonQQ|
+{
+  "type": "string"
+}
+|]
+
+-- ========================================================================
+-- UserId (non-record newtype)
+-- ========================================================================
+
+newtype UserId = UserId Integer
+  deriving (Generic, ToSchema)
+
+userIdSchemaJSON :: Value
+userIdSchemaJSON = [aesonQQ|
+{
+  "type": "integer"
+}
+|]
+
+-- ========================================================================
+-- Player (record newtype)
+-- ========================================================================
+
+newtype Player = Player
+  { position :: Point
+  } deriving (Generic, ToSchema)
+
+playerSchemaJSON :: Value
+playerSchemaJSON = [aesonQQ|
+{
+  "type": "object",
+  "properties":
+    {
+      "position":
+        {
+          "type": "object",
+          "properties":
+            {
+              "x": { "type": "number" },
+              "y": { "type": "number" }
+            },
+          "required": [ "x", "y" ]
+        }
+    },
+  "required": ["position"]
+}
+|]

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -18,8 +18,9 @@ checkToSchema proxy js = toSchema proxy <~> js
 
 spec :: Spec
 spec = do
-  describe "Generic ToSchema" $
+  describe "Generic ToSchema" $ do
     context "Person" $ checkToSchema (Proxy :: Proxy Person) personSchemaJSON
+    context "ISPair" $ checkToSchema (Proxy :: Proxy ISPair) ispairSchemaJSON
 
 main :: IO ()
 main = hspec spec
@@ -43,3 +44,19 @@ personSchemaJSON = [aesonQQ|
   "required": ["name", "phone"]
 }
 |]
+
+data ISPair = ISPair Integer String
+  deriving (Generic, ToSchema)
+
+ispairSchemaJSON :: Value
+ispairSchemaJSON = [aesonQQ|
+{
+  "type": "array",
+  "items":
+    [
+      { "type": "integer" },
+      { "type": "string"  }
+    ]
+}
+|]
+

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -304,7 +304,11 @@ playersSchemaJSON = [aesonQQ|
 data Status
   = StatusOk String
   | StatusError String
-  deriving (Generic, ToSchema)
+  deriving (Generic)
+
+instance ToSchema Status where
+  toNamedSchema = genericToNamedSchema defaultSchemaOptions
+    { constructorTagModifier = map toLower . drop (length "Status") }
 
 statusSchemaJSON :: Value
 statusSchemaJSON = [aesonQQ|
@@ -312,8 +316,8 @@ statusSchemaJSON = [aesonQQ|
   "type": "object",
   "properties":
     {
-      "StatusOk": { "type": "string" },
-      "StatusError": { "type": "string" }
+      "ok":    { "type": "string" },
+      "error": { "type": "string" }
     },
   "maxProperties": 1,
   "minProperties": 1

--- a/test/Data/SwaggerSpec.hs
+++ b/test/Data/SwaggerSpec.hs
@@ -15,30 +15,8 @@ import qualified Data.Vector as Vector
 import Data.Text (Text)
 
 import Data.Swagger
-
+import SpecCommon
 import Test.Hspec
-
-isSubJSON :: Value -> Value -> Bool
-isSubJSON Null _ = True
-isSubJSON (Object x) (Object y) = HashMap.keys x == HashMap.keys i && F.and i
-  where
-    i = HashMap.intersectionWith isSubJSON x y
-isSubJSON (Array xs) (Array ys) = Vector.length xs == Vector.length ys && F.and (Vector.zipWith isSubJSON xs ys)
-isSubJSON x y = x == y
-
-(<~>) :: (Eq a, Show a, ToJSON a, FromJSON a) => a -> Value -> Spec
-x <~> json = do
-  it "encodes correctly (probably with extra properties)" $ do
-    toJSON x `shouldSatisfy` (json `isSubJSON`)
-  it "decodes correctly" $ do
-    fromJSON json `shouldBe` Success x
-
-(<=>) :: (Eq a, Show a, ToJSON a, FromJSON a) => a -> Value -> Spec
-x <=> json = do
-  it "encodes correctly" $ do
-    toJSON x `shouldBe` json
-  it "decodes correctly" $ do
-    fromJSON json `shouldBe` Success x
 
 spec :: Spec
 spec = do

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import System.FilePath.Glob (glob)
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = glob "src/**/*.hs" >>= doctest

--- a/test/SpecCommon.hs
+++ b/test/SpecCommon.hs
@@ -1,0 +1,39 @@
+module SpecCommon where
+
+import Data.Aeson
+import Data.Aeson.QQ
+import qualified Data.Foldable as F
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import Data.Maybe
+import Data.Monoid
+import qualified Data.Vector as Vector
+import Data.Text (Text)
+
+import Data.Swagger
+
+import Test.Hspec
+
+isSubJSON :: Value -> Value -> Bool
+isSubJSON Null _ = True
+isSubJSON (Object x) (Object y) = HashMap.keys x == HashMap.keys i && F.and i
+  where
+    i = HashMap.intersectionWith isSubJSON x y
+isSubJSON (Array xs) (Array ys) = Vector.length xs == Vector.length ys && F.and (Vector.zipWith isSubJSON xs ys)
+isSubJSON x y = x == y
+
+(<~>) :: (Eq a, Show a, ToJSON a, FromJSON a) => a -> Value -> Spec
+x <~> json = do
+  it "encodes correctly (probably with extra properties)" $ do
+    toJSON x `shouldSatisfy` (json `isSubJSON`)
+  it "decodes correctly" $ do
+    fromJSON json `shouldBe` Success x
+
+(<=>) :: (Eq a, Show a, ToJSON a, FromJSON a) => a -> Value -> Spec
+x <=> json = do
+  it "encodes correctly" $ do
+    toJSON x `shouldBe` json
+  it "decodes correctly" $ do
+    fromJSON json `shouldBe` Success x
+
+


### PR DESCRIPTION
What's in:
- [x] `ToSchema` class with default `Generic`-based implementation;
- [x] `genericToSchema` working for some base types and record data types;
- [x] `toSchemaBoundedIntegral` and `toSchemaBoundedEnum` helpers;
- [x] introduce `Options` similar to `Data.Aeson.Options` (I have added `fieldLabelModifier`, what else do we need?);
- [x] more tests/examples;
- [x] more `ToSchema` instances for common types;
- [x] add `ToSchema` instances for `time` types;
- [ ] `ToParam`/`ToHeader` classes;
- [x] documentation.

@dmjio would this be useful for `servant-swagger`?