### PR TITLE
Introduce SwaggerItems GADT to simplify ParamSchema

### DIFF
--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -45,7 +45,7 @@ module Data.Swagger (
   -- * Schemas
   ParamSchema(..),
   Schema(..),
-  SchemaItems(..),
+  SwaggerItems(..),
   Xml(..),
 
   -- * Responses

--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -266,7 +266,7 @@ instance {-# OVERLAPPABLE #-} ToSchema a => ToSchema [a] where
     ref <- declareSchemaRef (Proxy :: Proxy a)
     return $ unnamed $ mempty
       & schemaType  .~ SwaggerArray
-      & schemaItems ?~ SchemaItemsObject ref
+      & schemaItems ?~ SwaggerItemsObject ref
 
 instance {-# OVERLAPPING #-} ToSchema String where declareNamedSchema = plain . paramSchemaToSchema
 instance ToSchema Bool    where declareNamedSchema = plain . paramSchemaToSchema
@@ -449,7 +449,7 @@ instance (Selector s, GToSchema f) => GToSchema (C1 c (S1 s f)) where
     | otherwise = do
         (_, schema) <- recordSchema
         case schema ^. schemaItems of
-          Just (SchemaItemsArray [_]) -> fieldSchema
+          Just (SwaggerItemsArray [_]) -> fieldSchema
           _ -> pure (unnamed schema)
     where
       recordSchema = gdeclareNamedSchema opts (Proxy :: Proxy (S1 s f)) s
@@ -474,10 +474,10 @@ gdeclareSchemaRef opts proxy = do
       return $ Ref (Reference name)
     _ -> Inline <$> gdeclareSchema opts proxy
 
-appendItem :: Referenced Schema -> Maybe SchemaItems -> Maybe SchemaItems
-appendItem x Nothing = Just (SchemaItemsArray [x])
-appendItem x (Just (SchemaItemsArray xs)) = Just (SchemaItemsArray (x:xs))
-appendItem _ _ = error "GToSchema.appendItem: cannot append to SchemaItemsObject"
+appendItem :: Referenced Schema -> Maybe (SwaggerItems Schema) -> Maybe (SwaggerItems Schema)
+appendItem x Nothing = Just (SwaggerItemsArray [x])
+appendItem x (Just (SwaggerItemsArray xs)) = Just (SwaggerItemsArray (x:xs))
+appendItem _ _ = error "GToSchema.appendItem: cannot append to SwaggerItemsObject"
 
 withFieldSchema :: forall proxy s f. (Selector s, GToSchema f) =>
   SchemaOptions -> proxy s f -> Bool -> Schema -> Declare Definitions Schema

--- a/src/Data/Swagger/Lens.hs
+++ b/src/Data/Swagger/Lens.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Data.Swagger.Lens where
@@ -43,8 +44,8 @@ makeLenses ''Items
 makeLenses ''Header
 -- ** 'Schema' lenses
 makeLenses ''Schema
--- ** 'SchemaItems' prisms
-makePrisms ''SchemaItems
+-- ** 'SwaggerItems' prisms
+makePrisms ''SwaggerItems
 -- ** 'ParamSchema' lenses
 makeLenses ''ParamSchema
 -- ** 'Xml' lenses
@@ -80,60 +81,60 @@ instance HasDescription Schema         (Maybe Text) where description = schemaDe
 instance HasDescription SecurityScheme (Maybe Text) where description = securitySchemeDescription
 instance HasDescription ExternalDocs   (Maybe Text) where description = externalDocsDescription
 
-class HasParamSchema s t i | s -> t i where
-  parameterSchema :: Lens' s (ParamSchema t i)
+class HasParamSchema s t | s -> t where
+  parameterSchema :: Lens' s (ParamSchema t)
 
-instance HasParamSchema Schema Schema SchemaItems where parameterSchema = schemaParamSchema
-instance HasParamSchema ParamOtherSchema ParamOtherSchema Items where parameterSchema = paramOtherSchemaParamSchema
-instance HasParamSchema Items Items Items where parameterSchema = itemsParamSchema
-instance HasParamSchema Header Header Items where parameterSchema = headerParamSchema
-instance HasParamSchema (ParamSchema t i) t i where parameterSchema = id
+instance HasParamSchema Schema Schema where parameterSchema = schemaParamSchema
+instance HasParamSchema ParamOtherSchema ParamOtherSchema where parameterSchema = paramOtherSchemaParamSchema
+instance HasParamSchema Items Items where parameterSchema = itemsParamSchema
+instance HasParamSchema Header Header where parameterSchema = headerParamSchema
+instance HasParamSchema (ParamSchema t) t where parameterSchema = id
 
-schemaType :: HasParamSchema s t i => Lens' s (SwaggerType t)
+schemaType :: HasParamSchema s t => Lens' s (SwaggerType t)
 schemaType = parameterSchema.paramSchemaType
 
-schemaFormat :: HasParamSchema s t i => Lens' s (Maybe Format)
+schemaFormat :: HasParamSchema s t => Lens' s (Maybe Format)
 schemaFormat = parameterSchema.paramSchemaFormat
 
-schemaItems :: HasParamSchema s t i => Lens' s (Maybe i)
+schemaItems :: HasParamSchema s t => Lens' s (Maybe (SwaggerItems t))
 schemaItems = parameterSchema.paramSchemaItems
 
-schemaDefault :: HasParamSchema s t i => Lens' s (Maybe Value)
+schemaDefault :: HasParamSchema s t => Lens' s (Maybe Value)
 schemaDefault = parameterSchema.paramSchemaDefault
 
-schemaMaximum :: HasParamSchema s t i => Lens' s (Maybe Scientific)
+schemaMaximum :: HasParamSchema s t => Lens' s (Maybe Scientific)
 schemaMaximum = parameterSchema.paramSchemaMaximum
 
-schemaExclusiveMaximum :: HasParamSchema s t i => Lens' s (Maybe Bool)
+schemaExclusiveMaximum :: HasParamSchema s t => Lens' s (Maybe Bool)
 schemaExclusiveMaximum = parameterSchema.paramSchemaExclusiveMaximum
 
-schemaMinimum :: HasParamSchema s t i => Lens' s (Maybe Scientific)
+schemaMinimum :: HasParamSchema s t => Lens' s (Maybe Scientific)
 schemaMinimum = parameterSchema.paramSchemaMinimum
 
-schemaExclusiveMinimum :: HasParamSchema s t i => Lens' s (Maybe Bool)
+schemaExclusiveMinimum :: HasParamSchema s t => Lens' s (Maybe Bool)
 schemaExclusiveMinimum = parameterSchema.paramSchemaExclusiveMinimum
 
-schemaMaxLength :: HasParamSchema s t i => Lens' s (Maybe Integer)
+schemaMaxLength :: HasParamSchema s t => Lens' s (Maybe Integer)
 schemaMaxLength = parameterSchema.paramSchemaMaxLength
 
-schemaMinLength :: HasParamSchema s t i => Lens' s (Maybe Integer)
+schemaMinLength :: HasParamSchema s t => Lens' s (Maybe Integer)
 schemaMinLength = parameterSchema.paramSchemaMinLength
 
-schemaPattern :: HasParamSchema s t i => Lens' s (Maybe Text)
+schemaPattern :: HasParamSchema s t => Lens' s (Maybe Text)
 schemaPattern = parameterSchema.paramSchemaPattern
 
-schemaMaxItems :: HasParamSchema s t i => Lens' s (Maybe Integer)
+schemaMaxItems :: HasParamSchema s t => Lens' s (Maybe Integer)
 schemaMaxItems = parameterSchema.paramSchemaMaxItems
 
-schemaMinItems :: HasParamSchema s t i => Lens' s (Maybe Integer)
+schemaMinItems :: HasParamSchema s t => Lens' s (Maybe Integer)
 schemaMinItems = parameterSchema.paramSchemaMinItems
 
-schemaUniqueItems :: HasParamSchema s t i => Lens' s (Maybe Bool)
+schemaUniqueItems :: HasParamSchema s t => Lens' s (Maybe Bool)
 schemaUniqueItems = parameterSchema.paramSchemaUniqueItems
 
-schemaEnum :: HasParamSchema s t i => Lens' s (Maybe [Value])
+schemaEnum :: HasParamSchema s t => Lens' s (Maybe [Value])
 schemaEnum = parameterSchema.paramSchemaEnum
 
-schemaMultipleOf :: HasParamSchema s t i => Lens' s (Maybe Scientific)
+schemaMultipleOf :: HasParamSchema s t => Lens' s (Maybe Scientific)
 schemaMultipleOf = parameterSchema.paramSchemaMultipleOf
 

--- a/test/Data/Swagger/ParamSchemaSpec.hs
+++ b/test/Data/Swagger/ParamSchemaSpec.hs
@@ -18,7 +18,7 @@ import SpecCommon
 import Test.Hspec
 
 checkToParamSchema :: ToParamSchema a => Proxy a -> Value -> Spec
-checkToParamSchema proxy js = (toParamSchema proxy :: ParamSchema Param Items) <=> js
+checkToParamSchema proxy js = (toParamSchema proxy :: ParamSchema Param) <=> js
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
Removes one type parameter from `ParamSchema` and allows to use less type annotations.

For instance, prior to this change this code required extra type annotation and gives a not very helpful type error:

```
>>> encode $ toParamSchema (Proxy :: Proxy Integer)

<interactive>:5:1:
    No instance for (ToJSON i0) arising from a use of ‘encode’
    The type variable ‘i0’ is ambiguous
    Note: there are several potential instances:
      instance ToJSON ApiKeyLocation
        -- Defined at /Users/nickolaykudasov/git/getshoptv/swagger2/src/Data/Swagger/Internal.hs:719:1
      instance ToJSON ApiKeyParams
        -- Defined at /Users/nickolaykudasov/git/getshoptv/swagger2/src/Data/Swagger/Internal.hs:720:1
      instance ToJSON (CollectionFormat t)
        -- Defined at /Users/nickolaykudasov/git/getshoptv/swagger2/src/Data/Swagger/Internal.hs:840:10
      ...plus 36 others
    In the expression: encode
    In the expression: encode $ toParamSchema (Proxy :: Proxy Int8)
    In an equation for ‘it’:
        it = encode $ toParamSchema (Proxy :: Proxy Int8)
```

This can be fixed by adding explicitly the (not very good looking) result type of `toParamSchema`:

```
>>> encode (toParamSchema (Proxy :: Proxy Integer) :: ParamSchema t Items)
"{\"type\":\"integer\"}"
```

With `SwaggerItems`, ambiguity disappears:

```
>>> encode $ toParamSchema (Proxy :: Proxy Integer)
"{\"type\":\"integer\"}"
```

`SwaggerItems` has a tiny disadvantage of allowing `Items` to be items type for `Schema`, but since it can always be converted naturally into `Schema`, it does not look bad. Besides, I don't expect library users to ever notice this or actually work with items directly.