### PR TITLE
Use formats from Swagger spec where appropriate

### DIFF
--- a/src/Data/Swagger/Internal/ParamSchema.hs
+++ b/src/Data/Swagger/Internal/ParamSchema.hs
@@ -82,8 +82,12 @@ instance ToParamSchema Integer where
 instance ToParamSchema Int    where toParamSchema = toParamSchemaBoundedIntegral
 instance ToParamSchema Int8   where toParamSchema = toParamSchemaBoundedIntegral
 instance ToParamSchema Int16  where toParamSchema = toParamSchemaBoundedIntegral
-instance ToParamSchema Int32  where toParamSchema = toParamSchemaBoundedIntegral
-instance ToParamSchema Int64  where toParamSchema = toParamSchemaBoundedIntegral
+
+instance ToParamSchema Int32 where
+  toParamSchema proxy = toParamSchemaBoundedIntegral proxy & schemaFormat ?~ "int32"
+
+instance ToParamSchema Int64 where
+  toParamSchema proxy = toParamSchemaBoundedIntegral proxy & schemaFormat ?~ "int64"
 
 instance ToParamSchema Word   where toParamSchema = toParamSchemaBoundedIntegral
 instance ToParamSchema Word8  where toParamSchema = toParamSchemaBoundedIntegral
@@ -111,21 +115,23 @@ instance ToParamSchema Scientific where
   toParamSchema _ = mempty & schemaType .~ SwaggerNumber
 
 instance ToParamSchema Double where
-  toParamSchema _ = mempty & schemaType .~ SwaggerNumber
+  toParamSchema _ = mempty
+    & schemaType   .~ SwaggerNumber
+    & schemaFormat ?~ "double"
 
 instance ToParamSchema Float where
-  toParamSchema _ = mempty & schemaType .~ SwaggerNumber
+  toParamSchema _ = mempty
+    & schemaType   .~ SwaggerNumber
+    & schemaFormat ?~ "float"
 
 timeParamSchema :: String -> ParamSchema t
 timeParamSchema format = mempty
   & schemaType      .~ SwaggerString
   & schemaFormat    ?~ T.pack format
 
--- |
--- >>> toParamSchema (Proxy :: Proxy Day) ^. schemaFormat
--- Just "yyyy-mm-dd"
+-- | Format @"date"@ corresponds to @yyyy-mm-dd@ format.
 instance ToParamSchema Day where
-  toParamSchema _ = timeParamSchema "yyyy-mm-dd"
+  toParamSchema _ = timeParamSchema "date"
 
 -- |
 -- >>> toParamSchema (Proxy :: Proxy LocalTime) ^. schemaFormat

--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -128,7 +128,7 @@ declareSchema = fmap snd . declareNamedSchema
 -- (Nothing,"{\"type\":\"string\"}")
 --
 -- >>> encode <$> toNamedSchema (Proxy :: Proxy Day)
--- (Just "Day","{\"format\":\"yyyy-mm-dd\",\"type\":\"string\"}")
+-- (Just "Day","{\"format\":\"date\",\"type\":\"string\"}")
 toNamedSchema :: ToSchema a => proxy a -> NamedSchema
 toNamedSchema = undeclare . declareNamedSchema
 
@@ -228,7 +228,7 @@ inlineAllSchemas = inlineSchemasWhen (const True)
 -- | Convert a type into a schema without references.
 --
 -- >>> encode $ toInlinedSchema (Proxy :: Proxy [Day])
--- "{\"items\":{\"format\":\"yyyy-mm-dd\",\"type\":\"string\"},\"type\":\"array\"}"
+-- "{\"items\":{\"format\":\"date\",\"type\":\"string\"},\"type\":\"array\"}"
 --
 -- __WARNING:__ @'toInlinedSchema'@ will produce infinite schema
 -- when inlining recursive schemas.
@@ -305,11 +305,9 @@ timeSchema format = mempty
   & schemaType .~ SwaggerString
   & schemaFormat ?~ format
 
--- |
--- >>> toSchema (Proxy :: Proxy Day) ^. schemaFormat
--- Just "yyyy-mm-dd"
+-- | Format @"date"@ corresponds to @yyyy-mm-dd@ format.
 instance ToSchema Day where
-  declareNamedSchema _ = pure $ named "Day" (timeSchema "yyyy-mm-dd")
+  declareNamedSchema _ = pure $ named "Day" (timeSchema "date")
 
 -- |
 -- >>> toSchema (Proxy :: Proxy LocalTime) ^. schemaFormat
@@ -317,11 +315,9 @@ instance ToSchema Day where
 instance ToSchema LocalTime where
   declareNamedSchema _ = pure $ named "LocalTime" (timeSchema "yyyy-mm-ddThh:MM:ss")
 
--- |
--- >>> toSchema (Proxy :: Proxy ZonedTime) ^. schemaFormat
--- Just "yyyy-mm-ddThh:MM:ss(Z|+hh:MM)"
+-- | Format @"date"@ corresponds to @yyyy-mm-ddThh:MM:ss(Z|+hh:MM)@ format.
 instance ToSchema ZonedTime where
-  declareNamedSchema _ = pure $ named "ZonedTime" $ timeSchema "yyyy-mm-ddThh:MM:ss(Z|+hh:MM)"
+  declareNamedSchema _ = pure $ named "ZonedTime" $ timeSchema "date-time"
 
 instance ToSchema NominalDiffTime where
   declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy Integer)

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -152,8 +152,8 @@ pointSchemaJSON = [aesonQQ|
   "type": "object",
   "properties":
     {
-      "x": { "type": "number" },
-      "y": { "type": "number" }
+      "x": { "type": "number", "format": "double" },
+      "y": { "type": "number", "format": "double" }
     },
   "required": ["x", "y"]
 }
@@ -458,8 +458,8 @@ characterInlinedSchemaJSON = [aesonQQ|
                   "type": "object",
                   "properties":
                     {
-                      "x": { "type": "number" },
-                      "y": { "type": "number" }
+                      "x": { "type": "number", "format": "double" },
+                      "y": { "type": "number", "format": "double" }
                     },
                   "required": ["x", "y"]
                 }
@@ -477,8 +477,8 @@ characterInlinedSchemaJSON = [aesonQQ|
                   "type": "object",
                   "properties":
                     {
-                      "x": { "type": "number" },
-                      "y": { "type": "number" }
+                      "x": { "type": "number", "format": "double" },
+                      "y": { "type": "number", "format": "double" }
                     },
                   "required": ["x", "y"]
                 }
@@ -545,9 +545,9 @@ lightSchemaJSON = [aesonQQ|
   "type": "object",
   "properties":
     {
-      "LightFreq": { "type": "number" },
+      "LightFreq": { "type": "number", "format": "double" },
       "LightColor": { "$ref": "#/definitions/Color" },
-      "LightWaveLength": { "type": "number" }
+      "LightWaveLength": { "type": "number", "format": "double" }
     },
   "maxProperties": 1,
   "minProperties": 1
@@ -560,13 +560,13 @@ lightInlinedSchemaJSON = [aesonQQ|
   "type": "object",
   "properties":
     {
-      "LightFreq": { "type": "number" },
+      "LightFreq": { "type": "number", "format": "double" },
       "LightColor":
         {
           "type": "string",
           "enum": ["Red", "Green", "Blue"]
         },
-      "LightWaveLength": { "type": "number" }
+      "LightWaveLength": { "type": "number", "format": "double" }
     },
   "maxProperties": 1,
   "minProperties": 1


### PR DESCRIPTION
Closes #29.

- Added formats for `Int32`, `Int64`, `Float` and `Double`;
- Changed formats for `Day` and `ZonedTime` (only for `ToSchema`).