### PR TITLE
Switch to classy field lenses

### DIFF
--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -33,8 +33,7 @@ module Data.Swagger (
   Contact(..),
   License(..),
 
-  -- ** Paths
-  Paths(..),
+  -- ** PathItem
   PathItem(..),
 
   -- ** Operations
@@ -164,13 +163,13 @@ import Data.Swagger.Internal
 -- also make it fairly simple to construct/modify any part of the specification:
 --
 -- >>> :{
--- encode $ mempty & pathsMap .~
---   [ ("/user", mempty & pathItemGet ?~ (mempty
---       & operationProduces ?~ MimeList ["application/json"]
---       & operationResponses .~ (mempty
---         & responsesResponses . at 200 ?~ Inline (mempty & responseSchema ?~ Ref (Reference "#/definitions/User")))))]
+-- encode $ (mempty :: Swagger) & paths .~
+--   [ ("/user", mempty & get ?~ (mempty
+--       & produces ?~ MimeList ["application/json"]
+--       & responses .~ (mempty
+--         & responses . at 200 ?~ Inline (mempty & schema ?~ Ref (Reference "#/definitions/User")))))]
 -- :}
--- "{\"/user\":{\"get\":{\"responses\":{\"200\":{\"schema\":{\"$ref\":\"#/definitions/#/definitions/User\"},\"description\":\"\"}},\"produces\":[\"application/json\"]}}}"
+-- "{\"swagger\":\"2.0\",\"info\":{\"version\":\"\",\"title\":\"\"},\"paths\":{\"/user\":{\"get\":{\"responses\":{\"200\":{\"schema\":{\"$ref\":\"#/definitions/#/definitions/User\"},\"description\":\"\"}},\"produces\":[\"application/json\"]}}}}"
 --
 -- In the snippet above we declare API paths with a single path @/user@ providing method @GET@
 -- which produces @application/json@ output and should respond with code @200@ and body specified
@@ -181,10 +180,10 @@ import Data.Swagger.Internal
 -- and allow them to be used by any type that has a @'ParamSchema'@:
 --
 -- >>> :{
--- encode $ mempty
---   & schemaTitle   ?~ "Email"
---   & schemaType    .~ SwaggerString
---   & schemaFormat  ?~ "email"
+-- encode $ (mempty :: Schema)
+--   & title  ?~ "Email"
+--   & type_  .~ SwaggerString
+--   & format ?~ "email"
 -- :}
 -- "{\"format\":\"email\",\"title\":\"Email\",\"type\":\"string\"}"
 

--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -159,32 +159,61 @@ import Data.Swagger.Internal
 -- $lens
 --
 -- Since @'Swagger'@ has a fairly complex structure, lenses and prisms are used
--- to modify this structure. In combination with @'Monoid'@ instances, lenses
--- also make it fairly simple to construct/modify any part of the specification:
+-- to work comfortly with it. In combination with @'Monoid'@ instances, lenses
+-- make it fairly simple to construct/modify any part of the specification:
 --
 -- >>> :{
--- encode $ (mempty :: Swagger) & paths .~
---   [ ("/user", mempty & get ?~ (mempty
---       & produces ?~ MimeList ["application/json"]
---       & at 200 ?~ Inline (mempty & schema ?~ Ref (Reference "#/definitions/User")))) ]
+-- encode $ (mempty :: Swagger)
+--   & definitions .~ [ ("User", mempty & type_ .~ SwaggerString) ]
+--   & paths .~
+--     [ ("/user", mempty & get ?~ (mempty
+--         & produces ?~ MimeList ["application/json"]
+--         & at 200 ?~ Inline (mempty & schema ?~ Ref (Reference "User")))) ]
 -- :}
--- "{\"swagger\":\"2.0\",\"info\":{\"version\":\"\",\"title\":\"\"},\"paths\":{\"/user\":{\"get\":{\"responses\":{\"200\":{\"schema\":{\"$ref\":\"#/definitions/#/definitions/User\"},\"description\":\"\"}},\"produces\":[\"application/json\"]}}}}"
+-- "{\"swagger\":\"2.0\",\"info\":{\"version\":\"\",\"title\":\"\"},\"definitions\":{\"User\":{\"type\":\"string\"}},\"paths\":{\"/user\":{\"get\":{\"responses\":{\"200\":{\"schema\":{\"$ref\":\"#/definitions/User\"},\"description\":\"\"}},\"produces\":[\"application/json\"]}}}}"
 --
--- In the snippet above we declare API paths with a single path @/user@ providing method @GET@
+-- In the snippet above we declare API with a single path @/user@ providing method @GET@
 -- which produces @application/json@ output and should respond with code @200@ and body specified
--- by schema @User@ (which should be defined in @definitions@ property of swagger specification).
+-- by schema @User@ which is defined in @'definitions'@ property of swagger specification.
 --
--- Since @'ParamSchema'@ is basically the /base schema specification/, a special
--- @'HasParamSchema'@ class has been introduced to generalize @'ParamSchema'@ lenses
--- and allow them to be used by any type that has a @'ParamSchema'@:
+-- For convenience, @swagger2@ uses /classy field lenses/. It means that
+-- field accessor names can be overloaded for different types. One such
+-- common field is @'description'@. Many components of Swagger specification
+-- can have descriptions, and you can use the same name for them:
 --
+-- >>> encode $ (mempty :: Response) & description .~ "No content"
+-- "{\"description\":\"No content\"}"
 -- >>> :{
 -- encode $ (mempty :: Schema)
---   & title  ?~ "Email"
---   & type_  .~ SwaggerString
---   & format ?~ "email"
+--   & type_       .~ SwaggerBoolean
+--   & description ?~ "To be or not to be"
 -- :}
--- "{\"format\":\"email\",\"title\":\"Email\",\"type\":\"string\"}"
+-- "{\"type\":\"boolean\",\"description\":\"To be or not to be\"}"
+--
+-- @'ParamSchema'@ is basically the /base schema specification/ and many types contain it (see @'HasParamSchema'@).
+-- So for convenience, all @'ParamSchema'@ fields are transitively made fields of the type that has it.
+-- For example, you can use @'type_'@ to access @'SwaggerType'@ of @'Header'@ schema without having to use @'paramSchema'@:
+--
+-- >>> encode $ (mempty :: Header) & type_ .~ SwaggerNumber
+-- "{\"type\":\"number\"}"
+--
+-- Additionally, to simplify working with @'Response'@, both @'Operation'@ and @'Responses'@
+-- have direct access to it via @'at' code@. Example:
+--
+-- >>> :{
+-- encode $ (mempty :: Operation)
+--   & at 404 ?~ Inline (mempty & description .~ "Not found")
+-- :}
+-- "{\"responses\":{\"404\":{\"description\":\"Not found\"}}}"
+--
+-- You might've noticed that @'type_'@ has an extra underscore in its name
+-- compared to, say, @'description'@ field accessor.
+-- This is because @type@ is a keyword in Haskell.
+-- A few other field accessors are modified in this way:
+--
+--    - @'in_'@, @'type_'@, @'default_'@ (as keywords);
+--    - @'maximum_'@ and @'minimum_'@ (as conflicting with @Prelude@);
+--    - @'enum_'@ (as conflicting with @Control.Lens@).
 
 -- $schema
 --
@@ -197,8 +226,8 @@ import Data.Swagger.Internal
 -- with properties in addition to what @'ParamSchema'@ provides.
 --
 -- In most cases you will have a Haskell data type for which you would like to
--- define a corresponding schema. To facilitate thise use case
--- this library provides two classes for schema encoding.
+-- define a corresponding schema. To facilitate this use case
+-- @swagger2@ provides two classes for schema encoding.
 -- Both these classes provide means to encode /types/ as Swagger /schemas/.
 --
 -- @'ToParamSchema'@ is intended to be used for primitive API endpoint parameters,

--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -166,8 +166,7 @@ import Data.Swagger.Internal
 -- encode $ (mempty :: Swagger) & paths .~
 --   [ ("/user", mempty & get ?~ (mempty
 --       & produces ?~ MimeList ["application/json"]
---       & responses .~ (mempty
---         & responses . at 200 ?~ Inline (mempty & schema ?~ Ref (Reference "#/definitions/User")))))]
+--       & at 200 ?~ Inline (mempty & schema ?~ Ref (Reference "#/definitions/User")))) ]
 -- :}
 -- "{\"swagger\":\"2.0\",\"info\":{\"version\":\"\",\"title\":\"\"},\"paths\":{\"/user\":{\"get\":{\"responses\":{\"200\":{\"schema\":{\"$ref\":\"#/definitions/#/definitions/User\"},\"description\":\"\"}},\"produces\":[\"application/json\"]}}}}"
 --

--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -40,61 +40,63 @@ type Definitions = HashMap Text
 data Swagger = Swagger
   { -- | Provides metadata about the API.
     -- The metadata can be used by the clients if needed.
-    _info :: Info
+    _swaggerInfo :: Info
 
     -- | The host (name or ip) serving the API. It MAY include a port.
     -- If the host is not included, the host serving the documentation is to be used (including the port).
-  , _host :: Maybe Host
+  , _swaggerHost :: Maybe Host
 
     -- | The base path on which the API is served, which is relative to the host.
     -- If it is not included, the API is served directly under the host.
     -- The value MUST start with a leading slash (/).
-  , _basePath :: Maybe FilePath
+  , _swaggerBasePath :: Maybe FilePath
 
     -- | The transfer protocol of the API.
     -- If the schemes is not included, the default scheme to be used is the one used to access the Swagger definition itself.
-  , _schemes :: Maybe [Scheme]
+  , _swaggerSchemes :: Maybe [Scheme]
 
     -- | A list of MIME types the APIs can consume.
     -- This is global to all APIs but can be overridden on specific API calls.
-  , _consumes :: MimeList
+  , _swaggerConsumes :: MimeList
 
     -- | A list of MIME types the APIs can produce.
     -- This is global to all APIs but can be overridden on specific API calls.
-  , _produces :: MimeList
+  , _swaggerProduces :: MimeList
 
     -- | The available paths and operations for the API.
-  , _paths :: Paths
+    -- Holds the relative paths to the individual endpoints.
+    -- The path is appended to the @'basePath'@ in order to construct the full URL.
+  , _swaggerPaths :: HashMap FilePath PathItem
 
     -- | An object to hold data types produced and consumed by operations.
-  , _definitions :: Definitions Schema
+  , _swaggerDefinitions :: Definitions Schema
 
     -- | An object to hold parameters that can be used across operations.
     -- This property does not define global parameters for all operations.
-  , _parameters :: Definitions Param
+  , _swaggerParameters :: Definitions Param
 
     -- | An object to hold responses that can be used across operations.
     -- This property does not define global responses for all operations.
-  , _responses :: Definitions Response
+  , _swaggerResponses :: Definitions Response
 
     -- | Security scheme definitions that can be used across the specification.
-  , _securityDefinitions :: Definitions SecurityScheme
+  , _swaggerSecurityDefinitions :: Definitions SecurityScheme
 
     -- | A declaration of which security schemes are applied for the API as a whole.
     -- The list of values describes alternative security schemes that can be used
     -- (that is, there is a logical OR between the security requirements).
     -- Individual operations can override this definition.
-  , _security :: [SecurityRequirement]
+  , _swaggerSecurity :: [SecurityRequirement]
 
     -- | A list of tags used by the specification with additional metadata.
     -- The order of the tags can be used to reflect on their order by the parsing tools.
     -- Not all tags that are used by the Operation Object must be declared.
     -- The tags that are not declared may be organized randomly or based on the tools' logic.
     -- Each tag name in the list MUST be unique.
-  , _tags :: [Tag]
+  , _swaggerTags :: [Tag]
 
     -- | Additional external documentation.
-  , _externalDocs :: Maybe ExternalDocs
+  , _swaggerExternalDocs :: Maybe ExternalDocs
   } deriving (Eq, Show, Generic, Data, Typeable)
 
 -- | The object provides metadata about the API.
@@ -169,13 +171,6 @@ data Scheme
   | Ws
   | Wss
   deriving (Eq, Show, Generic, Data, Typeable)
-
--- | The available paths and operations for the API.
-data Paths = Paths
-  { -- | Holds the relative paths to the individual endpoints.
-    -- The path is appended to the @'basePath'@ in order to construct the full URL.
-    _pathsMap         :: HashMap FilePath PathItem
-  } deriving (Eq, Show, Generic, Data, Typeable)
 
 -- | Describes the operations available on a single path.
 -- A @'PathItem'@ may be empty, due to ACL constraints.
@@ -719,10 +714,6 @@ instance Monoid Info where
   mempty = genericMempty
   mappend = genericMappend
 
-instance Monoid Paths where
-  mempty = genericMempty
-  mappend = genericMappend
-
 instance Monoid PathItem where
   mempty = genericMempty
   mappend = genericMappend
@@ -772,7 +763,6 @@ instance Monoid Example where
 -- =======================================================================
 
 instance SwaggerMonoid Info
-instance SwaggerMonoid Paths
 instance SwaggerMonoid PathItem
 instance SwaggerMonoid Schema
 instance SwaggerMonoid (ParamSchema t)
@@ -907,7 +897,7 @@ instance ToJSON SecuritySchemeType where
     <+> object [ "type" .= ("oauth2" :: Text) ]
 
 instance ToJSON Swagger where
-  toJSON = omitEmpties . addVersion . genericToJSON (jsonPrefix "")
+  toJSON = omitEmpties . addVersion . genericToJSON (jsonPrefix "swagger")
     where
       addVersion (Object o) = Object (HashMap.insert "swagger" "2.0" o)
       addVersion _ = error "impossible"
@@ -936,9 +926,6 @@ instance ToJSON Host where
     case mport of
       Nothing -> host
       Just port -> host ++ ":" ++ show port
-
-instance ToJSON Paths where
-  toJSON (Paths m) = toJSON m
 
 instance ToJSON MimeList where
   toJSON (MimeList xs) = toJSON (map show xs)
@@ -1037,7 +1024,7 @@ instance FromJSON Swagger where
   parseJSON js@(Object o) = do
     (version :: Text) <- o .: "swagger"
     when (version /= "2.0") empty
-    (genericParseJSON (jsonPrefix "")
+    (genericParseJSON (jsonPrefix "swagger")
       `withDefaults` [ "consumes" .= (mempty :: MimeList)
                      , "produces" .= (mempty :: MimeList)
                      , "security" .= ([] :: [SecurityRequirement])
@@ -1079,9 +1066,6 @@ instance FromJSON Host where
       (hostText, portText) = Text.breakOn ":" s
       [host, portStr] = map Text.unpack [hostText, portText]
   parseJSON _ = empty
-
-instance FromJSON Paths where
-  parseJSON js = Paths <$> parseJSON js
 
 instance FromJSON MimeList where
   parseJSON js = (MimeList . map fromString) <$> parseJSON js

--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -714,6 +714,10 @@ instance Monoid Info where
   mempty = genericMempty
   mappend = genericMappend
 
+instance Monoid Contact where
+  mempty = genericMempty
+  mappend = genericMappend
+
 instance Monoid PathItem where
   mempty = genericMempty
   mappend = genericMappend

--- a/src/Data/Swagger/Internal/ParamSchema.hs
+++ b/src/Data/Swagger/Internal/ParamSchema.hs
@@ -42,8 +42,8 @@ import Data.Swagger.SchemaOptions
 --
 -- instance ToParamSchema Direction where
 --   toParamSchema = mempty
---      & schemaType .~ SwaggerString
---      & schemaEnum .~ [ \"Up\", \"Down\" ]
+--      & type_ .~ SwaggerString
+--      & enum_ .~ [ \"Up\", \"Down\" ]
 -- @
 --
 -- Instead of manually writing your @'ToParamSchema'@ instance you can
@@ -74,23 +74,23 @@ class ToParamSchema a where
   toParamSchema = genericToParamSchema defaultSchemaOptions
 
 instance {-# OVERLAPPING #-} ToParamSchema String where
-  toParamSchema _ = mempty & schemaType .~ SwaggerString
+  toParamSchema _ = mempty & type_ .~ SwaggerString
 
 instance ToParamSchema Bool where
-  toParamSchema _ = mempty & schemaType .~ SwaggerBoolean
+  toParamSchema _ = mempty & type_ .~ SwaggerBoolean
 
 instance ToParamSchema Integer where
-  toParamSchema _ = mempty & schemaType .~ SwaggerInteger
+  toParamSchema _ = mempty & type_ .~ SwaggerInteger
 
 instance ToParamSchema Int    where toParamSchema = toParamSchemaBoundedIntegral
 instance ToParamSchema Int8   where toParamSchema = toParamSchemaBoundedIntegral
 instance ToParamSchema Int16  where toParamSchema = toParamSchemaBoundedIntegral
 
 instance ToParamSchema Int32 where
-  toParamSchema proxy = toParamSchemaBoundedIntegral proxy & schemaFormat ?~ "int32"
+  toParamSchema proxy = toParamSchemaBoundedIntegral proxy & format ?~ "int32"
 
 instance ToParamSchema Int64 where
-  toParamSchema proxy = toParamSchemaBoundedIntegral proxy & schemaFormat ?~ "int64"
+  toParamSchema proxy = toParamSchemaBoundedIntegral proxy & format ?~ "int64"
 
 instance ToParamSchema Word   where toParamSchema = toParamSchemaBoundedIntegral
 instance ToParamSchema Word8  where toParamSchema = toParamSchemaBoundedIntegral
@@ -104,52 +104,52 @@ instance ToParamSchema Word64 where toParamSchema = toParamSchemaBoundedIntegral
 -- "{\"maximum\":127,\"minimum\":-128,\"type\":\"integer\"}"
 toParamSchemaBoundedIntegral :: forall proxy a t. (Bounded a, Integral a) => proxy a -> ParamSchema t
 toParamSchemaBoundedIntegral _ = mempty
-  & schemaType .~ SwaggerInteger
-  & schemaMinimum ?~ fromInteger (toInteger (minBound :: a))
-  & schemaMaximum ?~ fromInteger (toInteger (maxBound :: a))
+  & type_ .~ SwaggerInteger
+  & minimum_ ?~ fromInteger (toInteger (minBound :: a))
+  & maximum_ ?~ fromInteger (toInteger (maxBound :: a))
 
 instance ToParamSchema Char where
   toParamSchema _ = mempty
-    & schemaType .~ SwaggerString
-    & schemaMaxLength ?~ 1
-    & schemaMinLength ?~ 1
+    & type_ .~ SwaggerString
+    & maxLength ?~ 1
+    & minLength ?~ 1
 
 instance ToParamSchema Scientific where
-  toParamSchema _ = mempty & schemaType .~ SwaggerNumber
+  toParamSchema _ = mempty & type_ .~ SwaggerNumber
 
 instance ToParamSchema Double where
   toParamSchema _ = mempty
-    & schemaType   .~ SwaggerNumber
-    & schemaFormat ?~ "double"
+    & type_  .~ SwaggerNumber
+    & format ?~ "double"
 
 instance ToParamSchema Float where
   toParamSchema _ = mempty
-    & schemaType   .~ SwaggerNumber
-    & schemaFormat ?~ "float"
+    & type_  .~ SwaggerNumber
+    & format ?~ "float"
 
 timeParamSchema :: String -> ParamSchema t
-timeParamSchema format = mempty
-  & schemaType      .~ SwaggerString
-  & schemaFormat    ?~ T.pack format
+timeParamSchema fmt = mempty
+  & type_  .~ SwaggerString
+  & format ?~ T.pack fmt
 
 -- | Format @"date"@ corresponds to @yyyy-mm-dd@ format.
 instance ToParamSchema Day where
   toParamSchema _ = timeParamSchema "date"
 
 -- |
--- >>> toParamSchema (Proxy :: Proxy LocalTime) ^. schemaFormat
+-- >>> toParamSchema (Proxy :: Proxy LocalTime) ^. format
 -- Just "yyyy-mm-ddThh:MM:ss"
 instance ToParamSchema LocalTime where
   toParamSchema _ = timeParamSchema "yyyy-mm-ddThh:MM:ss"
 
 -- |
--- >>> toParamSchema (Proxy :: Proxy ZonedTime) ^. schemaFormat
+-- >>> toParamSchema (Proxy :: Proxy ZonedTime) ^. format
 -- Just "yyyy-mm-ddThh:MM:ss+hhMM"
 instance ToParamSchema ZonedTime where
   toParamSchema _ = timeParamSchema "yyyy-mm-ddThh:MM:ss+hhMM"
 
 -- |
--- >>> toParamSchema (Proxy :: Proxy UTCTime) ^. schemaFormat
+-- >>> toParamSchema (Proxy :: Proxy UTCTime) ^. format
 -- Just "yyyy-mm-ddThh:MM:ssZ"
 instance ToParamSchema UTCTime where
   toParamSchema _ = timeParamSchema "yyyy-mm-ddThh:MM:ssZ"
@@ -173,12 +173,12 @@ instance ToParamSchema a => ToParamSchema (Dual a)    where toParamSchema _ = to
 
 instance ToParamSchema a => ToParamSchema [a] where
   toParamSchema _ = mempty
-    & schemaType  .~ SwaggerArray
-    & schemaItems ?~ SwaggerItemsPrimitive Nothing (toParamSchema (Proxy :: Proxy a))
+    & type_ .~ SwaggerArray
+    & items ?~ SwaggerItemsPrimitive Nothing (toParamSchema (Proxy :: Proxy a))
 
 instance ToParamSchema a => ToParamSchema (Set a) where
   toParamSchema _ = toParamSchema (Proxy :: Proxy [a])
-    & schemaUniqueItems ?~ True
+    & uniqueItems ?~ True
 
 instance ToParamSchema a => ToParamSchema (HashSet a) where
   toParamSchema _ = toParamSchema (Proxy :: Proxy (Set a))
@@ -188,8 +188,8 @@ instance ToParamSchema a => ToParamSchema (HashSet a) where
 -- "{\"type\":\"string\",\"enum\":[\"_\"]}"
 instance ToParamSchema () where
   toParamSchema _ = mempty
-    & schemaType .~ SwaggerString
-    & schemaEnum ?~ ["_"]
+    & type_ .~ SwaggerString
+    & enum_ ?~ ["_"]
 
 -- | A configurable generic @'ParamSchema'@ creator.
 --
@@ -226,8 +226,8 @@ instance (GEnumParamSchema f, GEnumParamSchema g) => GEnumParamSchema (f :+: g) 
 
 instance Constructor c => GEnumParamSchema (C1 c U1) where
   genumParamSchema opts _ s = s
-    & schemaType .~ SwaggerString
-    & schemaEnum %~ addEnumValue tag
+    & type_ .~ SwaggerString
+    & enum_ %~ addEnumValue tag
     where
       tag = toJSON (constructorTagModifier opts (conName (Proxy3 :: Proxy3 c f p)))
 

--- a/src/Data/Swagger/Lens.hs
+++ b/src/Data/Swagger/Lens.hs
@@ -16,37 +16,35 @@ import Data.Swagger.Internal
 import Data.Swagger.Internal.Utils
 import Data.Text (Text)
 
--- =======================================================================
--- * TH derived lenses
+-- * Classy lenses
 
--- ** 'Swagger' lenses
 makeFields ''Swagger
--- ** 'Host' lenses
 makeFields ''Host
--- ** 'Info' lenses
 makeFields ''Info
--- ** 'Contact' lenses
 makeFields ''Contact
--- ** 'License' lenses
 makeFields ''License
--- ** 'PathItem' lenses
 makeFields ''PathItem
--- ** 'Tag' lenses
 makeFields ''Tag
--- ** 'Operation' lenses
 makeFields ''Operation
--- ** 'Param' lenses
 makeFields ''Param
+makeLensesWith swaggerFieldRules ''ParamOtherSchema
+makeFields ''Header
+makeFields ''Schema
+makeFields ''NamedSchema
+makeLensesWith swaggerFieldRules ''ParamSchema
+makeFields ''Xml
+makeLensesWith swaggerFieldRules ''Responses
+makeFields ''Response
+makeLensesWith swaggerFieldRules ''SecurityScheme
+makeFields ''ApiKeyParams
+makeFields ''OAuth2Params
+makeFields ''ExternalDocs
+
+-- * Prisms
 -- ** 'ParamAnySchema' prisms
 makePrisms ''ParamAnySchema
--- ** 'ParamOtherSchema' lenses
-makeLensesWith swaggerFieldRules ''ParamOtherSchema
--- ** 'Header' lenses
-makeFields ''Header
--- ** 'Schema' lenses
-makeFields ''Schema
--- ** 'NamedSchema' lenses
-makeFields ''NamedSchema
+-- ** 'SecuritySchemeType' prisms
+makePrisms ''SecuritySchemeType
 
 -- ** 'SwaggerItems' prisms
 
@@ -66,25 +64,6 @@ _SwaggerItemsObject
 
 _SwaggerItemsPrimitive :: forall t p f. (Profunctor p, Bifunctor p, Functor f) => Optic' p f (SwaggerItems t) (Maybe (CollectionFormat t), ParamSchema t)
 _SwaggerItemsPrimitive = unto (\(c, p) -> SwaggerItemsPrimitive c p)
-
--- ** 'ParamSchema' lenses
-makeLensesWith swaggerFieldRules ''ParamSchema
--- ** 'Xml' lenses
-makeFields ''Xml
--- ** 'Responses' lenses
-makeLensesWith swaggerFieldRules ''Responses
--- ** 'Response' lenses
-makeFields ''Response
--- ** 'SecurityScheme' lenses
-makeLensesWith swaggerFieldRules ''SecurityScheme
--- ** 'SecuritySchemeType' prisms
-makePrisms ''SecuritySchemeType
--- ** 'ApiKeyParams' lenses
-makeFields ''ApiKeyParams
--- ** 'OAuth2Params' lenses
-makeFields ''OAuth2Params
--- ** 'ExternalDocs' lenses
-makeFields ''ExternalDocs
 
 -- =============================================================
 -- More helpful instances for easier access to schema properties

--- a/src/Data/Swagger/Lens.hs
+++ b/src/Data/Swagger/Lens.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Data.Swagger.Lens where
 
@@ -87,6 +88,18 @@ makeFields ''ExternalDocs
 
 -- =============================================================
 -- More helpful instances for easier access to schema properties
+
+type instance Index Responses = HttpStatusCode
+type instance Index Operation = HttpStatusCode
+
+type instance IxValue Responses = Referenced Response
+type instance IxValue Operation = Referenced Response
+
+instance Ixed Responses where ix n = responses . ix n
+instance At   Responses where at n = responses . at n
+
+instance Ixed Operation where ix n = responses . ix n
+instance At   Operation where at n = responses . at n
 
 -- HasType instances
 instance HasType Header (SwaggerType Header) where type_ = paramSchema.type_

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -40,6 +40,7 @@ library
                      , mtl
                      , network
                      , text
+                     , template-haskell
                      , time
                      , unordered-containers
                      , lens

--- a/test/Data/SwaggerSpec.hs
+++ b/test/Data/SwaggerSpec.hs
@@ -151,9 +151,9 @@ operationExample = mempty
       ]
 
     stringSchema :: ParamLocation -> ParamOtherSchema
-    stringSchema i = mempty
-      & paramOtherSchemaIn .~ i
-      & schemaType .~ SwaggerString
+    stringSchema loc = mempty
+      & in_ .~ loc
+      & type_ .~ SwaggerString
 
 operationExampleJSON :: Value
 operationExampleJSON = [aesonQQ|
@@ -219,8 +219,8 @@ operationExampleJSON = [aesonQQ|
 
 schemaPrimitiveExample :: Schema
 schemaPrimitiveExample = mempty
-  & schemaType    .~ SwaggerString
-  & schemaFormat  ?~ "email"
+  & type_  .~ SwaggerString
+  & format ?~ "email"
 
 schemaPrimitiveExampleJSON :: Value
 schemaPrimitiveExampleJSON = [aesonQQ|
@@ -232,15 +232,15 @@ schemaPrimitiveExampleJSON = [aesonQQ|
 
 schemaSimpleModelExample :: Schema
 schemaSimpleModelExample = mempty
-  & schemaType .~ SwaggerObject
-  & schemaRequired .~ [ "name" ]
-  & schemaProperties .~
-      [ ("name", Inline (mempty & schemaType .~ SwaggerString))
+  & type_ .~ SwaggerObject
+  & required .~ [ "name" ]
+  & properties .~
+      [ ("name", Inline (mempty & type_ .~ SwaggerString))
       , ("address", Ref (Reference "Address"))
       , ("age", Inline $ mempty
-            & schemaMinimum ?~ 0
-            & schemaType    .~ SwaggerInteger
-            & schemaFormat  ?~ "int32" ) ]
+            & minimum_ ?~ 0
+            & type_    .~ SwaggerInteger
+            & format   ?~ "int32" ) ]
 
 schemaSimpleModelExampleJSON :: Value
 schemaSimpleModelExampleJSON = [aesonQQ|
@@ -267,8 +267,8 @@ schemaSimpleModelExampleJSON = [aesonQQ|
 
 schemaModelDictExample :: Schema
 schemaModelDictExample = mempty
-  & schemaType .~ SwaggerObject
-  & schemaAdditionalProperties ?~ (mempty & schemaType .~ SwaggerString)
+  & type_ .~ SwaggerObject
+  & additionalProperties ?~ (mempty & type_ .~ SwaggerString)
 
 schemaModelDictExampleJSON :: Value
 schemaModelDictExampleJSON = [aesonQQ|
@@ -281,12 +281,12 @@ schemaModelDictExampleJSON = [aesonQQ|
 |]
 
 schemaWithExampleExample :: Schema
-schemaWithExampleExample = (mempty & schemaType .~ SwaggerObject)
+schemaWithExampleExample = (mempty & type_ .~ SwaggerObject)
   { _schemaProperties =
       [ ("id", Inline $ mempty
-            & schemaType .~ SwaggerInteger
-            & schemaFormat ?~ "int64" )
-      , ("name", Inline (mempty & schemaType .~ SwaggerString)) ]
+            & type_  .~ SwaggerInteger
+            & format ?~ "int64" )
+      , ("name", Inline (mempty & type_ .~ SwaggerString)) ]
   , _schemaRequired = [ "name" ]
   , _schemaExample = Just [aesonQQ|
       {
@@ -325,19 +325,19 @@ schemaWithExampleExampleJSON = [aesonQQ|
 definitionsExample :: HashMap Text Schema
 definitionsExample =
   [ ("Category", mempty
-      & schemaType .~ SwaggerObject
-      & schemaProperties .~
+      & type_ .~ SwaggerObject
+      & properties .~
           [ ("id", Inline $ mempty
-              & schemaType   .~ SwaggerInteger
-              & schemaFormat ?~ "int64")
-          , ("name", Inline (mempty & schemaType .~ SwaggerString)) ] )
+              & type_  .~ SwaggerInteger
+              & format ?~ "int64")
+          , ("name", Inline (mempty & type_ .~ SwaggerString)) ] )
   , ("Tag", mempty
-      & schemaType .~ SwaggerObject
-      & schemaProperties .~
+      & type_ .~ SwaggerObject
+      & properties .~
           [ ("id", Inline $ mempty
-              & schemaType   .~ SwaggerInteger
-              & schemaFormat ?~ "int64")
-          , ("name", Inline (mempty & schemaType .~ SwaggerString)) ] ) ]
+              & type_  .~ SwaggerInteger
+              & format ?~ "int64")
+          , ("name", Inline (mempty & type_ .~ SwaggerString)) ] ) ]
 
 definitionsExampleJSON :: Value
 definitionsExampleJSON = [aesonQQ|
@@ -380,17 +380,17 @@ paramsDefinitionExample =
       , _paramDescription = Just "number of items to skip"
       , _paramRequired = Just True
       , _paramSchema = ParamOther $ mempty
-          & paramOtherSchemaIn .~ ParamQuery
-          & schemaType .~ SwaggerInteger
-          & schemaFormat ?~ "int32" })
+          & in_    .~ ParamQuery
+          & type_  .~ SwaggerInteger
+          & format ?~ "int32" })
   , ("limitParam", mempty
       { _paramName = "limit"
       , _paramDescription = Just "max records to return"
       , _paramRequired = Just True
       , _paramSchema = ParamOther $ mempty
-          & paramOtherSchemaIn .~ ParamQuery
-          & schemaType .~ SwaggerInteger
-          & schemaFormat ?~ "int32" }) ]
+          & in_    .~ ParamQuery
+          & type_  .~ SwaggerInteger
+          & format ?~ "int32" }) ]
 
 paramsDefinitionExampleJSON :: Value
 paramsDefinitionExampleJSON = [aesonQQ|
@@ -478,45 +478,44 @@ securityDefinitionsExampleJSON = [aesonQQ|
 
 swaggerExample :: Swagger
 swaggerExample = mempty
-  { _basePath = Just "/"
-  , _schemes = Just [Http]
-  , _info = mempty
+  { _swaggerBasePath = Just "/"
+  , _swaggerSchemes = Just [Http]
+  , _swaggerInfo = mempty
       { _infoVersion = "1.0"
       , _infoTitle = "Todo API"
       , _infoLicense = Just License
           { _licenseName = "MIT"
           , _licenseUrl = Just (URL "http://mit.com") }
       , _infoDescription = Just "This is a an API that tests servant-swagger support for a Todo API" }
-  , _paths = mempty
-      { _pathsMap =
-          [ ("/todo/{id}", mempty
-              { _pathItemGet = Just mempty
-                  { _operationResponses = mempty
-                      { _responsesResponses =
-                          [ (200, Inline mempty
-                              { _responseSchema = Just $ Inline (mempty & schemaType .~ SwaggerObject)
-                                { _schemaExample = Just [aesonQQ|
-                                    {
-                                      "created": 100,
-                                      "description": "get milk"
-                                    } |]
-                                , _schemaDescription = Just "This is some real Todo right here"
-                                , _schemaProperties =
-                                    [ ("created", Inline $ mempty
-                                        & schemaType   .~ SwaggerInteger
-                                        & schemaFormat ?~ "int32")
-                                    , ("description", Inline (mempty & schemaType .~ SwaggerString)) ] }
-                              , _responseDescription = "OK" }) ] }
-                  , _operationProduces = Just (MimeList [ "application/json" ])
-                  , _operationParameters =
-                      [ Inline mempty
-                          { _paramRequired = Just True
-                          , _paramName = "id"
-                          , _paramDescription = Just "TodoId param"
-                          , _paramSchema = ParamOther $ mempty
-                              & paramOtherSchemaIn .~ ParamPath
-                              & schemaType .~ SwaggerString } ]
-                  , _operationTags = [ "todo" ] } }) ] } }
+  , _swaggerPaths =
+      [ ("/todo/{id}", mempty
+          { _pathItemGet = Just mempty
+              { _operationResponses = mempty
+                  { _responsesResponses =
+                      [ (200, Inline mempty
+                          { _responseSchema = Just $ Inline (mempty & type_ .~ SwaggerObject)
+                            { _schemaExample = Just [aesonQQ|
+                                {
+                                  "created": 100,
+                                  "description": "get milk"
+                                } |]
+                            , _schemaDescription = Just "This is some real Todo right here"
+                            , _schemaProperties =
+                                [ ("created", Inline $ mempty
+                                    & type_  .~ SwaggerInteger
+                                    & format ?~ "int32")
+                                , ("description", Inline (mempty & type_ .~ SwaggerString)) ] }
+                          , _responseDescription = "OK" }) ] }
+              , _operationProduces = Just (MimeList [ "application/json" ])
+              , _operationParameters =
+                  [ Inline mempty
+                      { _paramRequired = Just True
+                      , _paramName = "id"
+                      , _paramDescription = Just "TodoId param"
+                      , _paramSchema = ParamOther $ mempty
+                          & in_ .~ ParamPath
+                          & type_ .~ SwaggerString } ]
+              , _operationTags = [ "todo" ] } }) ] }
 
 swaggerExampleJSON :: Value
 swaggerExampleJSON = [aesonQQ|


### PR DESCRIPTION
Closes #39.

This change affects many names and types.
The goal is to make code look nicer.

Here's one example:

```diff
--- mempty
---   & schemaTitle   ?~ "Email"
---   & schemaType    .~ SwaggerString
---   & schemaFormat  ?~ "email"
+-- (mempty :: Schema)
+--   & title  ?~ "Email"
+--   & type_  .~ SwaggerString
+--   & format ?~ "email"
```

These names had to gain `_` suffix:
- `type_`, `in_`, `default_` (keywords);
- `minimum_`, `maximum_` (conflict with `Prelude`);
- `enum_` (conflict with `Control.Lens`).