### PR TITLE
RFC: using generics-sop to derive some ToJSON instances

### DIFF
--- a/src/Data/Swagger/Internal/AesonUtils.hs
+++ b/src/Data/Swagger/Internal/AesonUtils.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Data.Swagger.Internal.AesonUtils (
+    -- * Generic functions
+    sopSwaggerGenericToJSON,
+    -- * Options
+    SwaggerAesonOptions,
+    mkSwaggerAesonOptions,
+    saoPrefix,
+    saoAdditionalPairs,
+    saoSubObject,
+    ) where
+
+import Prelude ()
+import Prelude.Compat
+
+import Control.Lens (makeLenses, (^.))
+import Data.Aeson   (ToJSON(..), Value(..), object)
+import Data.Text    (Text)
+import Data.Char    (toLower, isUpper)
+
+import Generics.SOP
+
+import qualified Data.Text as T
+import qualified Data.HashMap.Strict as HM
+
+-------------------------------------------------------------------------------
+-- SwaggerAesonOptions
+-------------------------------------------------------------------------------
+
+data SwaggerAesonOptions = SwaggerAesonOptions
+    { _saoPrefix          :: String
+    , _saoAdditionalPairs :: [(Text, Value)]
+    , _saoSubObject       :: Maybe String
+    }
+
+mkSwaggerAesonOptions
+    :: String  -- ^ prefix
+    -> SwaggerAesonOptions
+mkSwaggerAesonOptions pfx = SwaggerAesonOptions pfx [] Nothing
+
+makeLenses ''SwaggerAesonOptions
+
+-------------------------------------------------------------------------------
+-- Generics
+-------------------------------------------------------------------------------
+
+-- | Generic serialisation for swagger records.
+--
+-- Features
+--
+-- * omits nulls, empty objects and empty arrays (configurable)
+-- * possible to add fields
+-- * possible to merge sub-object
+sopSwaggerGenericToJSON
+    :: forall a xs. (Generic a, HasDatatypeInfo a, All2 ToJSON (Code a), Code a ~ '[xs])
+    => SwaggerAesonOptions
+    -> a
+    -> Value
+sopSwaggerGenericToJSON opts x =
+    let ps = sopSwaggerGenericToJSON' opts (from x) (datatypeInfo (Proxy :: Proxy a))
+    in object (opts ^. saoAdditionalPairs ++ ps)
+
+sopSwaggerGenericToJSON' :: All2 ToJSON '[xs] => SwaggerAesonOptions -> SOP I '[xs] -> DatatypeInfo '[xs] -> [(Text, Value)]
+sopSwaggerGenericToJSON' opts (SOP (Z fields)) (ADT _ _ (Record _ fieldsInfo :* Nil)) =
+    sopSwaggerGenericToJSON'' opts fields fieldsInfo
+
+sopSwaggerGenericToJSON'' :: All ToJSON xs => SwaggerAesonOptions -> NP I xs -> NP FieldInfo xs -> [(Text, Value)]
+sopSwaggerGenericToJSON'' (SwaggerAesonOptions prefix _ sub) = go
+  where
+    go :: All ToJSON ys => NP I ys -> NP FieldInfo ys -> [(Text, Value)]
+    go  Nil Nil = []
+    go (I x :* xs) (FieldInfo name :* names)
+        | Just name' == sub = case json of
+              Object m -> HM.toList m ++ rest
+              Null     -> rest
+              _        -> error $ "sopSwaggerGenericToJSON: subjson is not an object: " ++ show json
+        | json == Null || json == Array mempty || json == Object mempty =
+            rest
+        | otherwise =
+            (T.pack name', json) : rest
+      where
+        json  = toJSON x
+        name' = fieldNameModifier name
+        rest  = go xs names
+
+    fieldNameModifier = modifier . drop 1
+    modifier = lowerFirstUppers . drop (length prefix)
+    lowerFirstUppers s = map toLower x ++ y
+      where (x, y) = span isUpper s

--- a/src/Data/Swagger/Internal/Utils.hs
+++ b/src/Data/Swagger/Internal/Utils.hs
@@ -85,23 +85,12 @@ parseOneOf xs js =
   where
     ys = zip (map toJSON xs) xs
 
-omitEmptiesExcept :: (Text -> Value -> Bool) -> Value -> Value
-omitEmptiesExcept f (Object o) = Object (HashMap.filterWithKey nonEmpty o)
-  where
-    nonEmpty k js = f k js || (js /= Object mempty) && (js /= Array mempty) && (js /= Null)
-omitEmptiesExcept _ js = js
-
+{-# DEPRECATED omitEmpties "will be removed" #-}
 omitEmpties :: Value -> Value
-omitEmpties = omitEmptiesExcept (\_ _ -> False)
-
-genericToJSONWithSub :: (Generic a, GToJSON (Rep a)) => Text -> Options -> a -> Value
-genericToJSONWithSub sub opts x =
-  case genericToJSON opts x of
-    Object o ->
-      case HashMap.lookup sub o of
-        Just so -> Object (HashMap.delete sub o) <+> so
-        Nothing -> Object o -- no subjson, leaving object as is
-    _ -> error "genericToJSONWithSub: subjson is not an object"
+omitEmpties (Object o) = Object (HashMap.filter nonEmpty o)
+  where
+    nonEmpty js = (js /= Object mempty) && (js /= Array mempty) && (js /= Null)
+omitEmpties js = js
 
 genericParseJSONWithSub :: (Generic a, GFromJSON (Rep a)) => Text -> Options -> Value -> Parser a
 genericParseJSONWithSub sub opts js@(Object o)

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -38,11 +38,13 @@ library
     Data.Swagger.Internal.Schema.Validation
     Data.Swagger.Internal.ParamSchema
     Data.Swagger.Internal.Utils
+    Data.Swagger.Internal.AesonUtils
   build-depends:       base        >=4.7   && <4.10
                      , base-compat >=0.6.0 && <0.10
                      , aeson
                      , containers
                      , hashable
+                     , generics-sop >=0.2 && <0.3
                      , http-media
                      , lens
                      , mtl


### PR DESCRIPTION
Related to https://github.com/GetShopTV/swagger2/pull/56 as using this we could write `sopSwaggerGenericToEncoding` as by making own generics derivation, we don't need to postprocess existing values (we cannot postprocess `Encoding!)

Here I also used `generics-sop`, as it's just much more straightforward (for me).