### PR TITLE
Bytestring type errors

### DIFF
--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -42,6 +42,7 @@ library
   build-depends:       base        >=4.7   && <4.10
                      , base-compat >=0.6.0 && <0.10
                      , aeson
+                     , bytestring
                      , containers
                      , hashable
                      , generics-sop >=0.2 && <0.3


### PR DESCRIPTION
Closes #77.

Here are the errors:

```
>>> toSchema (Proxy :: Proxy Lazy.ByteString)

<interactive>:5:1: error:
    • Impossible to have an instance ToSchema Lazy.ByteString.
      Please, use a newtype wrapper around Lazy.ByteString instead.
      Consider using byteSchema or binarySchema templates.
    • In the expression: toSchema (Proxy :: Proxy Lazy.ByteString)
      In an equation for ‘it’:
          it = toSchema (Proxy :: Proxy Lazy.ByteString)
```

```
>>> toParamSchema (Proxy :: Proxy BS.ByteString)

<interactive>:8:1: error:
    • Impossible to have an instance ToParamSchema BS.ByteString.
      Please, use a newtype wrapper around BS.ByteString instead.
      Consider using byteParamSchema or binaryParamSchema templates.
    • In the expression: toParamSchema (Proxy :: Proxy BS.ByteString)
      In an equation for ‘it’:
          it = toParamSchema (Proxy :: Proxy BS.ByteString)
```