### PR TITLE
Make MonadDeclare more useful

### DIFF
--- a/src/Data/Swagger/Declare.hs
+++ b/src/Data/Swagger/Declare.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -16,13 +15,11 @@ import Prelude ()
 import Prelude.Compat
 
 import Control.Monad
-import Control.Monad.Trans
 import Control.Monad.Cont (ContT)
-#if __GLASGOW_HASKELL__ >= 710
-import Control.Monad.Except (ExceptT)
-#endif
 import Control.Monad.List (ListT)
 import Control.Monad.Reader (ReaderT)
+import Control.Monad.Trans
+import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Identity (IdentityT)
 import Control.Monad.Trans.Maybe (MaybeT)
 import Control.Monad.Trans.Writer.Lazy as Lazy
@@ -154,11 +151,9 @@ instance MonadDeclare d m => MonadDeclare d (ContT r m) where
   declare = lift . declare
   look = lift look
 
-#if __GLASGOW_HASKELL__ >= 710
 instance MonadDeclare d m => MonadDeclare d (ExceptT e m) where
   declare = lift . declare
   look = lift look
-#endif
 
 instance MonadDeclare d m => MonadDeclare d (IdentityT m) where
   declare = lift . declare

--- a/src/Data/Swagger/Declare.hs
+++ b/src/Data/Swagger/Declare.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- |
 -- Module:      Data.Swagger.Declare
 -- Maintainer:  Nickolay Kudasov <nickolay@getshoptv.com>
@@ -15,6 +16,15 @@ import Prelude.Compat
 
 import Control.Monad
 import Control.Monad.Trans
+import Control.Monad.Cont (ContT)
+import Control.Monad.Error (Error, ErrorT)
+import Control.Monad.Except (ExceptT)
+import Control.Monad.List (ListT)
+import Control.Monad.Reader (ReaderT)
+import Control.Monad.Trans.Identity (IdentityT)
+import Control.Monad.Trans.Maybe (MaybeT)
+import Control.Monad.Trans.Writer.Lazy as Lazy
+import Control.Monad.Trans.Writer.Strict as Strict
 import Data.Functor.Identity
 import Data.Monoid
 
@@ -125,3 +135,45 @@ execDeclare m = runIdentity . execDeclareT m
 undeclare :: Monoid d => Declare d a -> a
 undeclare = runIdentity . undeclareT
 
+-- ---------------------------------------------------------------------------
+-- Instances for other mtl transformers
+--
+-- All of these instances need UndecidableInstances,
+-- because they do not satisfy the coverage condition.
+
+instance MonadDeclare d m => MonadDeclare d (ContT r m) where
+  declare = lift . declare
+  look = lift look
+
+-- Note: deprecated, fails with -Wall
+instance (Error e, MonadDeclare d m) => MonadDeclare d (ErrorT e m) where
+  declare = lift . declare
+  look = lift look
+
+instance MonadDeclare d m => MonadDeclare d (ExceptT e m) where
+  declare = lift . declare
+  look = lift look
+
+instance MonadDeclare d m => MonadDeclare d (IdentityT m) where
+  declare = lift . declare
+  look = lift look
+
+instance MonadDeclare d m => MonadDeclare d (ListT m) where
+  declare = lift . declare
+  look = lift look
+
+instance MonadDeclare d m => MonadDeclare d (MaybeT m) where
+  declare = lift . declare
+  look = lift look
+
+instance MonadDeclare d m => MonadDeclare d (ReaderT r m) where
+  declare = lift . declare
+  look = lift look
+
+instance (Monoid w, MonadDeclare d m) => MonadDeclare d (Lazy.WriterT w m) where
+  declare = lift . declare
+  look = lift look
+
+instance (Monoid w, MonadDeclare d m) => MonadDeclare d (Strict.WriterT w m) where
+  declare = lift . declare
+  look = lift look

--- a/src/Data/Swagger/Declare.hs
+++ b/src/Data/Swagger/Declare.hs
@@ -18,7 +18,6 @@ import Control.Monad
 import Control.Monad.Trans
 import Control.Monad.Cont (ContT)
 import Control.Monad.Error (Error, ErrorT)
-import Control.Monad.Except (ExceptT)
 import Control.Monad.List (ListT)
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.Trans.Identity (IdentityT)
@@ -157,9 +156,7 @@ instance (Error e, MonadDeclare d m) => MonadDeclare d (ErrorT e m) where
   declare = lift . declare
   look = lift look
 
-instance MonadDeclare d m => MonadDeclare d (ExceptT e m) where
-  declare = lift . declare
-  look = lift look
+-- Note: ExceptT not provided because it is not available in ghc 7.8.
 
 instance MonadDeclare d m => MonadDeclare d (IdentityT m) where
   declare = lift . declare

--- a/src/Data/Swagger/Declare.hs
+++ b/src/Data/Swagger/Declare.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -17,7 +18,9 @@ import Prelude.Compat
 import Control.Monad
 import Control.Monad.Trans
 import Control.Monad.Cont (ContT)
-import Control.Monad.Error (Error, ErrorT)
+#if __GLASGOW_HASKELL__ >= 710
+import Control.Monad.Except (ExceptT)
+#endif
 import Control.Monad.List (ListT)
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.Trans.Identity (IdentityT)
@@ -151,12 +154,11 @@ instance MonadDeclare d m => MonadDeclare d (ContT r m) where
   declare = lift . declare
   look = lift look
 
--- Note: deprecated, fails with -Wall
-instance (Error e, MonadDeclare d m) => MonadDeclare d (ErrorT e m) where
+#if __GLASGOW_HASKELL__ >= 710
+instance MonadDeclare d m => MonadDeclare d (ExceptT e m) where
   declare = lift . declare
   look = lift look
-
--- Note: ExceptT not provided because it is not available in ghc 7.8.
+#endif
 
 instance MonadDeclare d m => MonadDeclare d (IdentityT m) where
   declare = lift . declare

--- a/src/Data/Swagger/Declare.hs
+++ b/src/Data/Swagger/Declare.hs
@@ -87,6 +87,13 @@ instance (Applicative m, Monad m, Monoid d) => MonadDeclare d (DeclareT d m) whe
   declare d = DeclareT (\_ -> return (d, ()))
   look = DeclareT (\d -> return (mempty, d))
 
+-- | Lift a computation from the simple Declare monad.
+liftDeclare :: MonadDeclare d m => Declare d a -> m a
+liftDeclare da = do
+  (d', a) <- looks (runDeclare da)
+  declare d'
+  pure a
+
 -- | Retrieve a function of all the output so far.
 looks :: MonadDeclare d m => (d -> a) -> m a
 looks f = f <$> look

--- a/src/Data/Swagger/Declare.hs
+++ b/src/Data/Swagger/Declare.hs
@@ -22,6 +22,10 @@ import Control.Monad.Trans
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Identity (IdentityT)
 import Control.Monad.Trans.Maybe (MaybeT)
+import Control.Monad.Trans.State.Lazy as Lazy
+import Control.Monad.Trans.State.Strict as Strict
+import Control.Monad.Trans.RWS.Lazy as Lazy
+import Control.Monad.Trans.RWS.Strict as Strict
 import Control.Monad.Trans.Writer.Lazy as Lazy
 import Control.Monad.Trans.Writer.Strict as Strict
 import Data.Functor.Identity
@@ -168,6 +172,22 @@ instance MonadDeclare d m => MonadDeclare d (MaybeT m) where
   look = lift look
 
 instance MonadDeclare d m => MonadDeclare d (ReaderT r m) where
+  declare = lift . declare
+  look = lift look
+
+instance (Monoid w, MonadDeclare d m) => MonadDeclare d (Lazy.RWST r w s m) where
+  declare = lift . declare
+  look = lift look
+
+instance (Monoid w, MonadDeclare d m) => MonadDeclare d (Strict.RWST r w s m) where
+  declare = lift . declare
+  look = lift look
+
+instance MonadDeclare d m => MonadDeclare d (Lazy.StateT s m) where
+  declare = lift . declare
+  look = lift look
+
+instance MonadDeclare d m => MonadDeclare d (Strict.StateT s m) where
   declare = lift . declare
   look = lift look
 

--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -82,7 +82,7 @@ unnamed schema = NamedSchema Nothing schema
 named :: T.Text -> Schema -> NamedSchema
 named name schema = NamedSchema (Just name) schema
 
-plain :: MonadDeclare (Definitions Schema) m => Schema -> m NamedSchema
+plain :: Schema -> Declare (Definitions Schema) NamedSchema
 plain = pure . unnamed
 
 unname :: NamedSchema -> NamedSchema
@@ -138,12 +138,12 @@ class ToSchema a where
   -- together with all used definitions.
   -- Note that the schema itself is included in definitions
   -- only if it is recursive (and thus needs its definition in scope).
-  declareNamedSchema :: MonadDeclare (Definitions Schema) m => proxy a -> m NamedSchema
-  default declareNamedSchema :: (Generic a, GToSchema (Rep a), MonadDeclare (Definitions Schema) m) => proxy a -> m NamedSchema
+  declareNamedSchema :: proxy a -> Declare (Definitions Schema) NamedSchema
+  default declareNamedSchema :: (Generic a, GToSchema (Rep a)) => proxy a -> Declare (Definitions Schema) NamedSchema
   declareNamedSchema = genericDeclareNamedSchema defaultSchemaOptions
 
 -- | Convert a type into a schema and declare all used schema definitions.
-declareSchema :: (ToSchema a, MonadDeclare (Definitions Schema) m) => proxy a -> m Schema
+declareSchema :: ToSchema a => proxy a -> Declare (Definitions Schema) Schema
 declareSchema = fmap _namedSchemaSchema . declareNamedSchema
 
 -- | Convert a type into an optionally named schema.
@@ -198,7 +198,7 @@ toSchemaRef = undeclare . declareSchemaRef
 -- Schema definitions are typically declared for every referenced schema.
 -- If @'declareSchemaRef'@ returns a reference, a corresponding schema
 -- will be declared (regardless of whether it is recusive or not).
-declareSchemaRef :: (ToSchema a, MonadDeclare (Definitions Schema) m) => proxy a -> m (Referenced Schema)
+declareSchemaRef :: ToSchema a => proxy a -> Declare (Definitions Schema) (Referenced Schema)
 declareSchemaRef proxy = do
   case toNamedSchema proxy of
     NamedSchema (Just name) schema -> do
@@ -405,7 +405,7 @@ sketchStrictSchema = go . toJSON
         names = HashMap.keys o
 
 class GToSchema (f :: * -> *) where
-  gdeclareNamedSchema :: (MonadDeclare (Definitions Schema) m) => SchemaOptions -> proxy f -> Schema -> m NamedSchema
+  gdeclareNamedSchema :: SchemaOptions -> proxy f -> Schema -> Declare (Definitions Schema) NamedSchema
 
 instance OVERLAPPABLE_ ToSchema a => ToSchema [a] where
   declareNamedSchema _ = do
@@ -583,14 +583,14 @@ genericToNamedSchemaBoundedIntegral opts proxy
   = NamedSchema (gdatatypeSchemaName opts (Proxy :: Proxy d)) (toSchemaBoundedIntegral proxy)
 
 -- | A configurable generic @'Schema'@ creator.
-genericDeclareSchema :: (Generic a, GToSchema (Rep a), MonadDeclare (Definitions Schema) m) => SchemaOptions -> proxy a -> m Schema
+genericDeclareSchema :: (Generic a, GToSchema (Rep a)) => SchemaOptions -> proxy a -> Declare (Definitions Schema) Schema
 genericDeclareSchema opts proxy = _namedSchemaSchema <$> genericDeclareNamedSchema opts proxy
 
 -- | A configurable generic @'NamedSchema'@ creator.
 -- This function applied to @'defaultSchemaOptions'@
 -- is used as the default for @'declareNamedSchema'@
 -- when the type is an instance of @'Generic'@.
-genericDeclareNamedSchema :: forall a m proxy. (Generic a, GToSchema (Rep a), MonadDeclare (Definitions Schema) m) => SchemaOptions -> proxy a -> m NamedSchema
+genericDeclareNamedSchema :: forall a proxy. (Generic a, GToSchema (Rep a)) => SchemaOptions -> proxy a -> Declare (Definitions Schema) NamedSchema
 genericDeclareNamedSchema opts _ = gdeclareNamedSchema opts (Proxy :: Proxy (Rep a)) mempty
 
 gdatatypeSchemaName :: forall proxy d. Datatype d => SchemaOptions -> proxy d -> Maybe T.Text
@@ -618,7 +618,7 @@ nullarySchema = mempty
 gtoNamedSchema :: GToSchema f => SchemaOptions -> proxy f -> NamedSchema
 gtoNamedSchema opts proxy = undeclare $ gdeclareNamedSchema opts proxy mempty
 
-gdeclareSchema :: (GToSchema f, MonadDeclare (Definitions Schema) m) => SchemaOptions -> proxy f -> m Schema
+gdeclareSchema :: GToSchema f => SchemaOptions -> proxy f -> Declare (Definitions Schema) Schema
 gdeclareSchema opts proxy = _namedSchemaSchema <$> gdeclareNamedSchema opts proxy mempty
 
 instance (GToSchema f, GToSchema g) => GToSchema (f :*: g) where
@@ -652,7 +652,7 @@ instance (Selector s, GToSchema f) => GToSchema (C1 c (S1 s f)) where
       recordSchema = gdeclareNamedSchema opts (Proxy :: Proxy (S1 s f)) s
       fieldSchema  = gdeclareNamedSchema opts (Proxy :: Proxy f) s
 
-gdeclareSchemaRef :: (GToSchema a, MonadDeclare (Definitions Schema) m) => SchemaOptions -> proxy a -> m (Referenced Schema)
+gdeclareSchemaRef :: GToSchema a => SchemaOptions -> proxy a -> Declare (Definitions Schema) (Referenced Schema)
 gdeclareSchemaRef opts proxy = do
   case gtoNamedSchema opts proxy of
     NamedSchema (Just name) schema -> do
@@ -676,8 +676,8 @@ appendItem x Nothing = Just (SwaggerItemsArray [x])
 appendItem x (Just (SwaggerItemsArray xs)) = Just (SwaggerItemsArray (xs ++ [x]))
 appendItem _ _ = error "GToSchema.appendItem: cannot append to SwaggerItemsObject"
 
-withFieldSchema :: forall proxy s f m. (Selector s, GToSchema f, MonadDeclare (Definitions Schema) m) =>
-  SchemaOptions -> proxy s f -> Bool -> Schema -> m Schema
+withFieldSchema :: forall proxy s f. (Selector s, GToSchema f) =>
+  SchemaOptions -> proxy s f -> Bool -> Schema -> Declare (Definitions Schema) Schema
 withFieldSchema opts _ isRequiredField schema = do
   ref <- gdeclareSchemaRef opts (Proxy :: Proxy f)
   return $
@@ -713,12 +713,11 @@ instance OVERLAPPABLE_ ToSchema c => GToSchema (K1 i c) where
 instance (GSumToSchema f, GSumToSchema g) => GToSchema (f :+: g) where
   gdeclareNamedSchema = gdeclareNamedSumSchema
 
-gdeclareNamedSumSchema :: (GSumToSchema f, MonadDeclare (Definitions Schema) m) => SchemaOptions -> proxy f -> Schema -> m NamedSchema
+gdeclareNamedSumSchema :: GSumToSchema f => SchemaOptions -> proxy f -> Schema -> Declare (Definitions Schema) NamedSchema
 gdeclareNamedSumSchema opts proxy s
   | allNullaryToStringTag opts && allNullary = pure $ unnamed (toStringTag sumSchema)
   | otherwise = (unnamed . fst) <$> runWriterT declareSumSchema
   where
-    declareSumSchema :: MonadDeclare (Definitions Schema) m => WriterT AllNullary m Schema
     declareSumSchema = gsumToSchema opts proxy s
     (sumSchema, All allNullary) = undeclare (runWriterT declareSumSchema)
 
@@ -729,7 +728,7 @@ gdeclareNamedSumSchema opts proxy s
 type AllNullary = All
 
 class GSumToSchema f where
-  gsumToSchema :: MonadDeclare (Definitions Schema) m => SchemaOptions -> proxy f -> Schema -> WriterT AllNullary m Schema
+  gsumToSchema :: SchemaOptions -> proxy f -> Schema -> WriterT AllNullary (Declare (Definitions Schema)) Schema
 
 instance (GSumToSchema f, GSumToSchema g) => GSumToSchema (f :+: g) where
   gsumToSchema opts _ = gsumToSchema opts (Proxy :: Proxy f) >=> gsumToSchema opts (Proxy :: Proxy g)
@@ -744,8 +743,8 @@ gsumConToSchemaWith ref opts _ schema = schema
   where
     tag = T.pack (constructorTagModifier opts (conName (Proxy3 :: Proxy3 c f p)))
 
-gsumConToSchema :: forall c f m proxy. (GToSchema (C1 c f), Constructor c, MonadDeclare (Definitions Schema) m) =>
-  SchemaOptions -> proxy (C1 c f) -> Schema -> m Schema
+gsumConToSchema :: forall c f proxy. (GToSchema (C1 c f), Constructor c) =>
+  SchemaOptions -> proxy (C1 c f) -> Schema -> Declare (Definitions Schema) Schema
 gsumConToSchema opts proxy schema = do
   ref <- gdeclareSchemaRef opts proxy
   return $ gsumConToSchemaWith ref opts proxy schema
@@ -766,3 +765,4 @@ instance Constructor c => GSumToSchema (C1 c U1) where
 data Proxy2 a b = Proxy2
 
 data Proxy3 a b c = Proxy3
+

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -56,6 +56,7 @@ library
                      , template-haskell
                      , time
                      , transformers
+                     , transformers-compat >= 0.3
                      , unordered-containers
                      , vector
                      , uuid-types >=1.0.2 && <1.1


### PR DESCRIPTION
Fixes #96.

The first commit adds instances for the standard transformers. Note: an instance is provided for `ErrorT`, which produces a deprecation warning when it's compiled.

The second commit changes the types in Schema.hs to use `MonadDeclare`. Note: this changes the type of `declareNamedSchema` which may effect users of the library who provide instances of `ToSchema`, so it may be considered a breaking change. However, I believe most reasonable implementations will continue to compile.