### PR TITLE
Make buildable with 8.2.1

### DIFF
--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -729,7 +729,7 @@ gdeclareNamedSumSchema opts proxy s
 
 type AllNullary = All
 
-class GSumToSchema f where
+class GSumToSchema (f :: * -> *)  where
   gsumToSchema :: SchemaOptions -> proxy f -> Schema -> WriterT AllNullary (Declare (Definitions Schema)) Schema
 
 instance (GSumToSchema f, GSumToSchema g) => GSumToSchema (f :+: g) where

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -39,7 +39,7 @@ library
     Data.Swagger.Internal.ParamSchema
     Data.Swagger.Internal.Utils
     Data.Swagger.Internal.AesonUtils
-  build-depends:       base        >=4.7   && <4.10
+  build-depends:       base        >=4.7   && <4.11
                      , base-compat >=0.9.1 && <0.10
                      , aeson       >=0.11.2.1
                      , bytestring


### PR DESCRIPTION
This makes swagger2 buildable with GHC 8.2.1-rc2. Fixes #95 with the change suggested there by @RyanGlScott