### PR TITLE
Add Identity instances

### DIFF
--- a/src/Data/Swagger/Internal/ParamSchema.hs
+++ b/src/Data/Swagger/Internal/ParamSchema.hs
@@ -225,6 +225,8 @@ instance ToParamSchema a => ToParamSchema (First a)   where toParamSchema _ = to
 instance ToParamSchema a => ToParamSchema (Last a)    where toParamSchema _ = toParamSchema (Proxy :: Proxy a)
 instance ToParamSchema a => ToParamSchema (Dual a)    where toParamSchema _ = toParamSchema (Proxy :: Proxy a)
 
+instance ToParamSchema a => ToParamSchema (Identity a) where toParamSchema _ = toParamSchema (Proxy :: Proxy a)
+
 instance ToParamSchema a => ToParamSchema [a] where
   toParamSchema _ = mempty
     & type_ .~ SwaggerArray

--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -562,6 +562,8 @@ instance ToSchema a => ToSchema (First a)   where declareNamedSchema _ = unname 
 instance ToSchema a => ToSchema (Last a)    where declareNamedSchema _ = unname <$> declareNamedSchema (Proxy :: Proxy a)
 instance ToSchema a => ToSchema (Dual a)    where declareNamedSchema _ = unname <$> declareNamedSchema (Proxy :: Proxy a)
 
+instance ToSchema a => ToSchema (Identity a) where declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy a)
+
 -- | Default schema for @'Bounded'@, @'Integral'@ types.
 --
 -- >>> encode $ toSchemaBoundedIntegral (Proxy :: Proxy Int16)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-8.0
+resolver: lts-9.3
 packages:
 - '.'


### PR DESCRIPTION
Closes #115.

I bumped the Stack resolver since things wouldn't build with lts-8.0.

Also, I wasn't sure whether the `ToSchema` instance should be using `unname` or not; I don't really understand why some existing instances use it and some don't.