### PR TITLE
Constraint derived shapes

### DIFF
--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -64,6 +64,7 @@ import Data.Swagger.Internal.ParamSchema (ToParamSchema(..))
 import Data.Swagger.Lens hiding (name, schema)
 import qualified Data.Swagger.Lens as Swagger
 import Data.Swagger.SchemaOptions
+import Data.Swagger.Internal.TypeShape
 
 #if __GLASGOW_HASKELL__ < 800
 #else
@@ -708,7 +709,12 @@ instance OVERLAPPING_ ToSchema c => GToSchema (K1 i (Maybe c)) where
 instance OVERLAPPABLE_ ToSchema c => GToSchema (K1 i c) where
   gdeclareNamedSchema _ _ _ = declareNamedSchema (Proxy :: Proxy c)
 
-instance (GSumToSchema f, GSumToSchema g) => GToSchema (f :+: g) where
+instance ( GSumToSchema f
+         , GSumToSchema g
+         , LegalShape (GenericShape (f :+: g))
+         
+         ) => GToSchema (f :+: g) 
+   where
   gdeclareNamedSchema = gdeclareNamedSumSchema
 
 gdeclareNamedSumSchema :: GSumToSchema f => SchemaOptions -> proxy f -> Schema -> Declare (Definitions Schema) NamedSchema

--- a/src/Data/Swagger/Internal/TypeShape.hs
+++ b/src/Data/Swagger/Internal/TypeShape.hs
@@ -1,0 +1,60 @@
+
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+
+module Data.Swagger.Internal.TypeShape where
+
+
+import Data.Proxy
+import GHC.Generics
+import GHC.TypeLits
+ 
+data TypeShape = EnumShape
+               | NestedShape
+               | IlegalShape
+
+
+type family ProdCombine (a :: TypeShape ) (b :: TypeShape) :: TypeShape where
+        
+        ProdCombine IlegalShape b           = IlegalShape
+        ProdCombine a           IlegalShape = IlegalShape
+        ProdCombine a           b           = NestedShape
+
+
+type family SumCombine (a :: TypeShape ) (b :: TypeShape) :: TypeShape where
+        
+        SumCombine  EnumShape   EnumShape   = EnumShape
+        SumCombine  NestedShape NestedShape = NestedShape
+        SumCombine  a           b           = IlegalShape
+
+
+
+
+class LegalShape (a :: TypeShape) where
+
+instance LegalShape EnumShape
+instance LegalShape NestedShape
+
+instance TypeError 
+       (    Text "Cannot auto derive swagger class, for that to be possible, make sure that any constructor " 
+       :$$: Text "for this type, only holds 0 arguments if there are no other contructors with more than 0 arguments,"
+       :$$: Text "otherwise, every constructor have to hold at least 1 argument"    
+       ) => LegalShape IlegalShape
+
+
+
+type family GenericShape ( g :: * -> * ) :: TypeShape
+
+
+type instance GenericShape (f :*: g)        = ProdCombine  (GenericShape f) (GenericShape g)
+type instance GenericShape (f :+: g)        = SumCombine   (GenericShape f) (GenericShape g)
+type instance GenericShape (D1  d f)        = GenericShape f
+type instance GenericShape (C1 c U1)        = EnumShape
+type instance GenericShape (C1 c (S1 s f))  = NestedShape
+type instance GenericShape (C1 c (f :*: g)) = NestedShape
+
+

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -47,6 +47,7 @@ library
     Data.Swagger.Internal.ParamSchema
     Data.Swagger.Internal.Utils
     Data.Swagger.Internal.AesonUtils
+    Data.Swagger.Internal.TypeShape
   build-depends:       base        >=4.7   && <4.11
                      , base-compat >=0.9.1 && <0.10
                      , aeson       >=0.11.2.1


### PR DESCRIPTION
Type level checking derived instances are not problematic (related to issue #74), failing to compile otherwise.