### PR TITLE
Type error by default on mixed sum types

### DIFF
--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- |
 -- Module:      Data.Swagger
 -- Maintainer:  Nickolay Kudasov <nickolay@getshoptv.com>
@@ -288,6 +289,21 @@ import Data.Swagger.Internal
 --
 -- we can not derive a valid schema for a mix of the above. The following will result in a type error
 --
+#if __GLASGOW_HASKELL__ < 800
+-- >>> data BadMixedType = ChoiceBool Bool | JustTag deriving Generic
+-- >>> instance ToSchema BadMixedType
+-- ...
+-- ... error:
+-- ... • No instance for (Data.Swagger.Internal.TypeShape.CannotDeriveSchemaForMixedSumType
+-- ...                      BadMixedType)
+-- ...     arising from a use of ‘Data.Swagger.Internal.Schema.$dmdeclareNamedSchema’
+-- ... • In the expression:
+-- ...     Data.Swagger.Internal.Schema.$dmdeclareNamedSchema @BadMixedType
+-- ...   In an equation for ‘declareNamedSchema’:
+-- ...       declareNamedSchema
+-- ...         = Data.Swagger.Internal.Schema.$dmdeclareNamedSchema @BadMixedType
+-- ...   In the instance declaration for ‘ToSchema BadMixedType’
+#else
 -- >>> data BadMixedType = ChoiceBool Bool | JustTag deriving Generic
 -- >>> instance ToSchema BadMixedType
 -- ...
@@ -304,6 +320,7 @@ import Data.Swagger.Internal
 -- ...       declareNamedSchema
 -- ...         = Data.Swagger.Internal.Schema.$dmdeclareNamedSchema @BadMixedType
 -- ...   In the instance declaration for ‘ToSchema BadMixedType’
+#endif
 --
 -- We can use 'genericDeclareNamedSchemaUnrestricted' to try our best to represent this type as a Swagger Schema and match 'ToJSON':
 --

--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -286,13 +286,30 @@ import Data.Swagger.Internal
 -- >>> instance ToSchema SampleSumType
 -- >>> instance ToJSON SampleSumType
 --
--- we can not derive a valid schema for a mix of the above. The following will result in a bad schema
--- 
+-- we can not derive a valid schema for a mix of the above. The following will result in a type error
+--
 -- >>> data BadMixedType = ChoiceBool Bool | JustTag deriving Generic
 -- >>> instance ToSchema BadMixedType
--- >>> instance ToJSON BadMixedType
+-- ...
+-- ... error:
+-- ... • Cannot derive Generic-based Swagger Schema for BadMixedType
+-- ...   BadMixedType is a mixed sum type (has both unit and non-unit constructors).
+-- ...   Swagger does not have a good representation for these types.
+-- ...   Use genericDeclareNamedSchemaUnrestricted if you want to derive schema
+-- ...   that matches aeson's Generic-based toJSON,
+-- ...   but that's not supported by some Swagger tools.
+-- ... • In the expression:
+-- ...     Data.Swagger.Internal.Schema.$dmdeclareNamedSchema @BadMixedType
+-- ...   In an equation for ‘declareNamedSchema’:
+-- ...       declareNamedSchema
+-- ...         = Data.Swagger.Internal.Schema.$dmdeclareNamedSchema @BadMixedType
+-- ...   In the instance declaration for ‘ToSchema BadMixedType’
 --
--- This is due to the fact that @'ToJSON'@ encodes empty constructors with an empty list which can not be described in a swagger schema.
+-- We can use 'genericDeclareNamedSchemaUnrestricted' to try our best to represent this type as a Swagger Schema and match 'ToJSON':
+--
+-- >>> data BadMixedType = ChoiceBool Bool | JustTag deriving Generic
+-- >>> instance ToSchema BadMixedType where declareNamedSchema = genericDeclareNamedSchemaUnrestricted defaultSchemaOptions
+-- >>> instance ToJSON BadMixedType
 --
 
 -- $manipulation

--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -64,6 +64,7 @@ import Data.Swagger.Internal.ParamSchema (ToParamSchema(..))
 import Data.Swagger.Lens hiding (name, schema)
 import qualified Data.Swagger.Lens as Swagger
 import Data.Swagger.SchemaOptions
+import Data.Swagger.Internal.TypeShape
 
 #if __GLASGOW_HASKELL__ < 800
 #else
@@ -708,7 +709,12 @@ instance OVERLAPPING_ ToSchema c => GToSchema (K1 i (Maybe c)) where
 instance OVERLAPPABLE_ ToSchema c => GToSchema (K1 i c) where
   gdeclareNamedSchema _ _ _ = declareNamedSchema (Proxy :: Proxy c)
 
-instance (GSumToSchema f, GSumToSchema g) => GToSchema (f :+: g) where
+instance ( GSumToSchema f
+         , GSumToSchema g
+         , LegalShape (GenericShape (f :+: g))
+         
+         ) => GToSchema (f :+: g) 
+   where
   gdeclareNamedSchema = gdeclareNamedSumSchema
 
 gdeclareNamedSumSchema :: GSumToSchema f => SchemaOptions -> proxy f -> Schema -> Declare (Definitions Schema) NamedSchema

--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/src/Data/Swagger/Internal/TypeShape.hs
+++ b/src/Data/Swagger/Internal/TypeShape.hs
@@ -1,0 +1,60 @@
+
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+
+module Data.Swagger.Internal.TypeShape where
+
+
+import Data.Proxy
+import GHC.Generics
+import GHC.TypeLits
+ 
+data TypeShape = EnumShape
+               | NestedShape
+               | IlegalShape
+
+
+type family ProdCombine (a :: TypeShape ) (b :: TypeShape) :: TypeShape where
+        
+        ProdCombine IlegalShape b           = IlegalShape
+        ProdCombine a           IlegalShape = IlegalShape
+        ProdCombine a           b           = NestedShape
+
+
+type family SumCombine (a :: TypeShape ) (b :: TypeShape) :: TypeShape where
+        
+        SumCombine  EnumShape   EnumShape   = EnumShape
+        SumCombine  NestedShape NestedShape = NestedShape
+        SumCombine  a           b           = IlegalShape
+
+
+
+
+class LegalShape (a :: TypeShape) where
+
+instance LegalShape EnumShape
+instance LegalShape NestedShape
+
+instance TypeError 
+       (    Text "Cannot auto derive swagger class, for that to be possible, make sure that any constructor " 
+       :$$: Text "for this type, only holds 0 arguments if there are no other contructors with more than 0 arguments,"
+       :$$: Text "otherwise, every constructor have to hold at least 1 argument"    
+       ) => LegalShape IlegalShape
+
+
+
+type family GenericShape ( g :: * -> * ) :: TypeShape
+
+
+type instance GenericShape (f :*: g)        = ProdCombine  (GenericShape f) (GenericShape g)
+type instance GenericShape (f :+: g)        = SumCombine   (GenericShape f) (GenericShape g)
+type instance GenericShape (D1  d f)        = GenericShape f
+type instance GenericShape (C1 c U1)        = EnumShape
+type instance GenericShape (C1 c (S1 s f))  = NestedShape
+type instance GenericShape (C1 c (f :*: g)) = NestedShape
+
+

--- a/src/Data/Swagger/Internal/TypeShape.hs
+++ b/src/Data/Swagger/Internal/TypeShape.hs
@@ -1,60 +1,59 @@
-
-{-# LANGUAGE KindSignatures        #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
-
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Data.Swagger.Internal.TypeShape where
-
 
 import Data.Proxy
 import GHC.Generics
 import GHC.TypeLits
- 
-data TypeShape = EnumShape
-               | NestedShape
-               | IlegalShape
+import GHC.Exts (Constraint)
 
+-- | Shape of a datatype.
+data TypeShape
+  = Enumeration     -- ^ A simple enumeration.
+  | SumOfProducts   -- ^ A product or a sum of non-unit products.
+  | Mixed           -- ^ Mixed sum type with both unit and non-unit constructors.
 
-type family ProdCombine (a :: TypeShape ) (b :: TypeShape) :: TypeShape where
-        
-        ProdCombine IlegalShape b           = IlegalShape
-        ProdCombine a           IlegalShape = IlegalShape
-        ProdCombine a           b           = NestedShape
+-- | A combined shape for a product type.
+type family ProdCombine (a :: TypeShape) (b :: TypeShape) :: TypeShape where
+  ProdCombine Mixed b     = Mixed   -- technically this cannot happen since Haskell types are sums of products
+  ProdCombine a     Mixed = Mixed   -- technically this cannot happen since Haskell types are sums of products
+  ProdCombine a     b     = SumOfProducts
 
+-- | A combined shape for a sum type.
+type family SumCombine (a :: TypeShape) (b :: TypeShape) :: TypeShape where
+  SumCombine Enumeration   Enumeration   = Enumeration
+  SumCombine SumOfProducts SumOfProducts = SumOfProducts
+  SumCombine a b = Mixed
 
-type family SumCombine (a :: TypeShape ) (b :: TypeShape) :: TypeShape where
-        
-        SumCombine  EnumShape   EnumShape   = EnumShape
-        SumCombine  NestedShape NestedShape = NestedShape
-        SumCombine  a           b           = IlegalShape
+type family TypeHasSimpleShape t (f :: Symbol) :: Constraint where
+  TypeHasSimpleShape t f = GenericHasSimpleShape t f (GenericShape (Rep t))
 
+type family GenericHasSimpleShape t (f :: Symbol) (s :: TypeShape) :: Constraint where
+  GenericHasSimpleShape t f Enumeration   = ()
+  GenericHasSimpleShape t f SumOfProducts = ()
+  GenericHasSimpleShape t f Mixed =
+    TypeError
+      (     Text "Cannot derive Generic-based Swagger Schema for " :<>: ShowType t
+      :$$:  ShowType t :<>: Text " is a mixed sum type (has both unit and non-unit constructors)."
+      :$$:  Text "Swagger does not have a good representation for these types."
+      :$$:  Text "Use " :<>: Text f :<>: Text " if you want to derive schema"
+      :$$:  Text "that matches aeson's Generic-based toJSON,"
+      :$$:  Text "but that's not supported by some Swagger tools."
+      )
 
-
-
-class LegalShape (a :: TypeShape) where
-
-instance LegalShape EnumShape
-instance LegalShape NestedShape
-
-instance TypeError 
-       (    Text "Cannot auto derive swagger class, for that to be possible, make sure that any constructor " 
-       :$$: Text "for this type, only holds 0 arguments if there are no other contructors with more than 0 arguments,"
-       :$$: Text "otherwise, every constructor have to hold at least 1 argument"    
-       ) => LegalShape IlegalShape
-
-
-
-type family GenericShape ( g :: * -> * ) :: TypeShape
-
+-- | Infer a 'TypeShape' for a generic representation of a type.
+type family GenericShape (g :: * -> *) :: TypeShape
 
 type instance GenericShape (f :*: g)        = ProdCombine  (GenericShape f) (GenericShape g)
 type instance GenericShape (f :+: g)        = SumCombine   (GenericShape f) (GenericShape g)
 type instance GenericShape (D1  d f)        = GenericShape f
-type instance GenericShape (C1 c U1)        = EnumShape
-type instance GenericShape (C1 c (S1 s f))  = NestedShape
-type instance GenericShape (C1 c (f :*: g)) = NestedShape
+type instance GenericShape (C1 c U1)        = Enumeration
+type instance GenericShape (C1 c (S1 s f))  = SumOfProducts
+type instance GenericShape (C1 c (f :*: g)) = SumOfProducts
 
 

--- a/src/Data/Swagger/Internal/TypeShape.hs
+++ b/src/Data/Swagger/Internal/TypeShape.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
@@ -36,6 +37,11 @@ type family TypeHasSimpleShape t (f :: Symbol) :: Constraint where
 type family GenericHasSimpleShape t (f :: Symbol) (s :: TypeShape) :: Constraint where
   GenericHasSimpleShape t f Enumeration   = ()
   GenericHasSimpleShape t f SumOfProducts = ()
+#if __GLASGOW_HASKELL__ < 800
+  GenericHasSimpleShape t f Mixed = CannotDeriveSchemaForMixedSumType t
+
+class CannotDeriveSchemaForMixedSumType t where
+#else
   GenericHasSimpleShape t f Mixed =
     TypeError
       (     Text "Cannot derive Generic-based Swagger Schema for " :<>: ShowType t
@@ -45,6 +51,7 @@ type family GenericHasSimpleShape t (f :: Symbol) (s :: TypeShape) :: Constraint
       :$$:  Text "that matches aeson's Generic-based toJSON,"
       :$$:  Text "but that's not supported by some Swagger tools."
       )
+#endif
 
 -- | Infer a 'TypeShape' for a generic representation of a type.
 type family GenericShape (g :: * -> *) :: TypeShape

--- a/src/Data/Swagger/Schema.hs
+++ b/src/Data/Swagger/Schema.hs
@@ -22,6 +22,10 @@ module Data.Swagger.Schema (
   paramSchemaToNamedSchema,
   paramSchemaToSchema,
 
+  -- ** Unrestricted versions
+  genericDeclareNamedSchemaUnrestricted,
+  genericDeclareSchemaUnrestricted,
+
   -- * Schema templates
   passwordSchema,
   binarySchema,

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -47,6 +47,7 @@ library
     Data.Swagger.Internal.ParamSchema
     Data.Swagger.Internal.Utils
     Data.Swagger.Internal.AesonUtils
+    Data.Swagger.Internal.TypeShape
   build-depends:       base        >=4.7   && <4.11
                      , base-compat >=0.9.1 && <0.10
                      , aeson       >=0.11.2.1

--- a/test/Data/Swagger/Schema/ValidationSpec.hs
+++ b/test/Data/Swagger/Schema/ValidationSpec.hs
@@ -148,7 +148,8 @@ instance Arbitrary MyRoseTree where
 
 data Light = NoLight | LightFreq Double | LightColor Color deriving (Show, Generic)
 
-instance ToSchema Light
+instance ToSchema Light where
+  declareNamedSchema = genericDeclareNamedSchemaUnrestricted defaultSchemaOptions
 
 instance ToJSON Light where
   toJSON = genericToJSON defaultOptions { sumEncoding = ObjectWithSingleField }

--- a/test/Data/Swagger/SchemaSpec.hs
+++ b/test/Data/Swagger/SchemaSpec.hs
@@ -599,7 +599,7 @@ data Light
   deriving (Generic)
 
 instance ToSchema Light where
-  declareNamedSchema = genericDeclareNamedSchema defaultSchemaOptions
+  declareNamedSchema = genericDeclareNamedSchemaUnrestricted defaultSchemaOptions
     { unwrapUnaryRecords = True }
 
 lightSchemaJSON :: Value


### PR DESCRIPTION
Contents of this PR:

- Type error by default on mixed sum types (with GHC's custom type errors to explain situation);
- Improved documentation;
- Unrestricted versions for `genericDeclareSchema` and `genericDeclareNamedSchema` for convenience.

@vwwv I have worked a bit on your PR, I hope you don't mind :)
Could you proof-read before I merge?