### PR TITLE
Add support for additionalProperties with Bool value

### DIFF
--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -77,6 +77,7 @@ module Data.Swagger (
   SwaggerItems(..),
   Xml(..),
   Pattern,
+  AdditionalProperties(..),
 
   -- ** Responses
   Responses(..),

--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -529,7 +529,7 @@ instance (ToJSONKey k, ToSchema k, ToSchema v) => ToSchema (Map k v) where
         schema <- declareSchemaRef (Proxy :: Proxy v)
         return $ unnamed $ mempty
           & type_ .~ SwaggerObject
-          & additionalProperties ?~ schema
+          & additionalProperties ?~ AdditionalPropertiesSchema schema
 
 instance (ToJSONKey k, ToSchema k, ToSchema v) => ToSchema (HashMap k v) where
   declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy (Map k v))

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,6 @@ packages:
 - '.'
 extra-deps:
 - aeson-1.3.1.0
-- base-compat-0.10.0
-- base-compat-batteries-0.10.0
+- base-compat-0.10.1
+- base-compat-batteries-0.10.1
 - insert-ordered-containers-0.2.1.0

--- a/test/Data/SwaggerSpec.hs
+++ b/test/Data/SwaggerSpec.hs
@@ -37,6 +37,7 @@ spec = do
     context "Primitive Sample" $ schemaPrimitiveExample <=> schemaPrimitiveExampleJSON
     context "Simple Model" $ schemaSimpleModelExample <=> schemaSimpleModelExampleJSON
     context "Model with Map/Dictionary Properties" $ schemaModelDictExample <=> schemaModelDictExampleJSON
+    context "Model with Arbitrary Properties" $ schemaAdditionalExample <=> schemaAdditionalExampleJSON
     context "Model with Example" $ schemaWithExampleExample <=> schemaWithExampleExampleJSON
   describe "Definitions Object" $ definitionsExample <=> definitionsExampleJSON
   describe "Parameters Definition Object" $ paramsDefinitionExample <=> paramsDefinitionExampleJSON
@@ -272,7 +273,7 @@ schemaSimpleModelExampleJSON = [aesonQQ|
 schemaModelDictExample :: Schema
 schemaModelDictExample = mempty
   & type_ .~ SwaggerObject
-  & additionalProperties ?~ Inline (mempty & type_ .~ SwaggerString)
+  & additionalProperties ?~ AdditionalPropertiesSchema (Inline (mempty & type_ .~ SwaggerString))
 
 schemaModelDictExampleJSON :: Value
 schemaModelDictExampleJSON = [aesonQQ|
@@ -281,6 +282,19 @@ schemaModelDictExampleJSON = [aesonQQ|
   "additionalProperties": {
     "type": "string"
   }
+}
+|]
+
+schemaAdditionalExample :: Schema
+schemaAdditionalExample = mempty
+  & type_ .~ SwaggerObject
+  & additionalProperties ?~ AdditionalPropertiesAllowed True
+
+schemaAdditionalExampleJSON :: Value
+schemaAdditionalExampleJSON = [aesonQQ|
+{
+  "type": "object",
+  "additionalProperties": true
 }
 |]
 


### PR DESCRIPTION
According to the spec ([here](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.18)), `additionalProperties` can be `true` (meaning additional properties with any values) or `false` (meaning the same thing as the attribute not being present, I believe) or a schema.

This commit adds a new type, `AdditionalProperties`, with custom JSON encoding to deal with that, and what appears to be reasonable validation for it.

I did not write a test that validation actually does anything sensible with this new option, because it wasn't clear to me where that would go, but I'd be happy to look into it if the basic approach taken here seems reasonable.