### PR TITLE
Fix #138 schema type becomes optional

### DIFF
--- a/examples/hackage.hs
+++ b/examples/hackage.hs
@@ -27,7 +27,7 @@ instance ToSchema UserSummary where
     usernameSchema <- declareSchemaRef (Proxy :: Proxy Username)
     useridSchema   <- declareSchemaRef (Proxy :: Proxy Int)
     return $ NamedSchema (Just "UserSummary") $ mempty
-      & type_ .~ SwaggerObject
+      & type_ ?~ SwaggerObject
       & properties .~
           [ ("summaryUsername", usernameSchema )
           , ("summaryUserid"  , useridSchema   )

--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -181,7 +181,7 @@ import Data.Swagger.Internal
 --
 -- >>> :{
 -- encode $ (mempty :: Swagger)
---   & definitions .~ [ ("User", mempty & type_ .~ SwaggerString) ]
+--   & definitions .~ [ ("User", mempty & type_ ?~ SwaggerString) ]
 --   & paths .~
 --     [ ("/user", mempty & get ?~ (mempty
 --         & produces ?~ MimeList ["application/json"]
@@ -204,7 +204,7 @@ import Data.Swagger.Internal
 -- "{\"description\":\"No content\"}"
 -- >>> :{
 -- encode $ (mempty :: Schema)
---   & type_       .~ SwaggerBoolean
+--   & type_       ?~ SwaggerBoolean
 --   & description ?~ "To be or not to be"
 -- :}
 -- "{\"description\":\"To be or not to be\",\"type\":\"boolean\"}"
@@ -213,7 +213,7 @@ import Data.Swagger.Internal
 -- So for convenience, all @'ParamSchema'@ fields are transitively made fields of the type that has it.
 -- For example, you can use @'type_'@ to access @'SwaggerType'@ of @'Header'@ schema without having to use @'paramSchema'@:
 --
--- >>> encode $ (mempty :: Header) & type_ .~ SwaggerNumber
+-- >>> encode $ (mempty :: Header) & type_ ?~ SwaggerNumber
 -- "{\"type\":\"number\"}"
 --
 -- Additionally, to simplify working with @'Response'@, both @'Operation'@ and @'Responses'@

--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -589,7 +589,7 @@ data ParamSchema (t :: SwaggerKind *) = ParamSchema
     -- Unlike JSON Schema this value MUST conform to the defined type for this parameter.
     _paramSchemaDefault :: Maybe Value
 
-  , _paramSchemaType :: SwaggerType t
+  , _paramSchemaType :: Maybe (SwaggerType t)
   , _paramSchemaFormat :: Maybe Format
   , _paramSchemaItems :: Maybe (SwaggerItems t)
   , _paramSchemaMaximum :: Maybe Scientific
@@ -606,7 +606,7 @@ data ParamSchema (t :: SwaggerKind *) = ParamSchema
   , _paramSchemaMultipleOf :: Maybe Scientific
   } deriving (Eq, Show, Generic, Typeable)
 
-deriving instance (Typeable k, Data (SwaggerType k), Data (SwaggerItems k)) => Data (ParamSchema k)
+deriving instance (Typeable k, Data (Maybe (SwaggerType k)), Data (SwaggerItems k)) => Data (ParamSchema k)
 
 data Xml = Xml
   { -- | Replaces the name of the element/attribute used for the described schema property.

--- a/src/Data/Swagger/Internal/ParamSchema.hs
+++ b/src/Data/Swagger/Internal/ParamSchema.hs
@@ -58,20 +58,20 @@ import GHC.TypeLits (TypeError, ErrorMessage(..))
 -- | Default schema for binary data (any sequence of octets).
 binaryParamSchema :: ParamSchema t
 binaryParamSchema = mempty
-  & type_ .~ SwaggerString
+  & type_ ?~ SwaggerString
   & format ?~ "binary"
 
 -- | Default schema for binary data (base64 encoded).
 byteParamSchema :: ParamSchema t
 byteParamSchema = mempty
-  & type_ .~ SwaggerString
+  & type_ ?~ SwaggerString
   & format ?~ "byte"
 
 -- | Default schema for password string.
 -- @"password"@ format is used to hint UIs the input needs to be obscured.
 passwordParamSchema :: ParamSchema t
 passwordParamSchema = mempty
-  & type_ .~ SwaggerString
+  & type_ ?~ SwaggerString
   & format ?~ "password"
 
 -- | Convert a type into a plain @'ParamSchema'@.
@@ -87,7 +87,7 @@ passwordParamSchema = mempty
 --
 -- instance ToParamSchema Direction where
 --   toParamSchema _ = mempty
---      & type_ .~ SwaggerString
+--      & type_ ?~ SwaggerString
 --      & enum_ ?~ [ \"Up\", \"Down\" ]
 -- @
 --
@@ -119,17 +119,17 @@ class ToParamSchema a where
   toParamSchema = genericToParamSchema defaultSchemaOptions
 
 instance OVERLAPPING_ ToParamSchema String where
-  toParamSchema _ = mempty & type_ .~ SwaggerString
+  toParamSchema _ = mempty & type_ ?~ SwaggerString
 
 instance ToParamSchema Bool where
-  toParamSchema _ = mempty & type_ .~ SwaggerBoolean
+  toParamSchema _ = mempty & type_ ?~ SwaggerBoolean
 
 instance ToParamSchema Integer where
-  toParamSchema _ = mempty & type_ .~ SwaggerInteger
+  toParamSchema _ = mempty & type_ ?~ SwaggerInteger
 
 instance ToParamSchema Natural where
   toParamSchema _ = mempty
-    & type_            .~ SwaggerInteger
+    & type_            ?~ SwaggerInteger
     & minimum_         ?~ 0
     & exclusiveMinimum ?~ False
 
@@ -155,37 +155,37 @@ instance ToParamSchema Word64 where toParamSchema = toParamSchemaBoundedIntegral
 -- "{\"maximum\":127,\"minimum\":-128,\"type\":\"integer\"}"
 toParamSchemaBoundedIntegral :: forall proxy a t. (Bounded a, Integral a) => proxy a -> ParamSchema t
 toParamSchemaBoundedIntegral _ = mempty
-  & type_ .~ SwaggerInteger
+  & type_ ?~ SwaggerInteger
   & minimum_ ?~ fromInteger (toInteger (minBound :: a))
   & maximum_ ?~ fromInteger (toInteger (maxBound :: a))
 
 instance ToParamSchema Char where
   toParamSchema _ = mempty
-    & type_ .~ SwaggerString
+    & type_ ?~ SwaggerString
     & maxLength ?~ 1
     & minLength ?~ 1
 
 instance ToParamSchema Scientific where
-  toParamSchema _ = mempty & type_ .~ SwaggerNumber
+  toParamSchema _ = mempty & type_ ?~ SwaggerNumber
 
 instance HasResolution a => ToParamSchema (Fixed a) where
   toParamSchema _ = mempty
-    & type_      .~ SwaggerNumber
+    & type_      ?~ SwaggerNumber
     & multipleOf ?~ (recip . fromInteger $ resolution (Proxy :: Proxy a))
 
 instance ToParamSchema Double where
   toParamSchema _ = mempty
-    & type_  .~ SwaggerNumber
+    & type_  ?~ SwaggerNumber
     & format ?~ "double"
 
 instance ToParamSchema Float where
   toParamSchema _ = mempty
-    & type_  .~ SwaggerNumber
+    & type_  ?~ SwaggerNumber
     & format ?~ "float"
 
 timeParamSchema :: String -> ParamSchema t
 timeParamSchema fmt = mempty
-  & type_  .~ SwaggerString
+  & type_  ?~ SwaggerString
   & format ?~ T.pack fmt
 
 -- | Format @"date"@ corresponds to @yyyy-mm-dd@ format.
@@ -221,7 +221,7 @@ instance ToParamSchema TL.Text where
 
 instance ToParamSchema Version where
   toParamSchema _ = mempty
-    & type_ .~ SwaggerString
+    & type_ ?~ SwaggerString
     & pattern ?~ "^\\d+(\\.\\d+)*$"
 
 #if __GLASGOW_HASKELL__ < 800
@@ -248,7 +248,7 @@ instance ToParamSchema a => ToParamSchema (Identity a) where toParamSchema _ = t
 
 instance ToParamSchema a => ToParamSchema [a] where
   toParamSchema _ = mempty
-    & type_ .~ SwaggerArray
+    & type_ ?~ SwaggerArray
     & items ?~ SwaggerItemsPrimitive Nothing (toParamSchema (Proxy :: Proxy a))
 
 instance ToParamSchema a => ToParamSchema (V.Vector a) where toParamSchema _ = toParamSchema (Proxy :: Proxy [a])
@@ -268,12 +268,12 @@ instance ToParamSchema a => ToParamSchema (HashSet a) where
 -- "{\"type\":\"string\",\"enum\":[\"_\"]}"
 instance ToParamSchema () where
   toParamSchema _ = mempty
-    & type_ .~ SwaggerString
+    & type_ ?~ SwaggerString
     & enum_ ?~ ["_"]
 
 instance ToParamSchema UUID where
   toParamSchema _ = mempty
-    & type_ .~ SwaggerString
+    & type_ ?~ SwaggerString
     & format ?~ "uuid"
 
 -- | A configurable generic @'ParamSchema'@ creator.
@@ -311,7 +311,7 @@ instance (GEnumParamSchema f, GEnumParamSchema g) => GEnumParamSchema (f :+: g) 
 
 instance Constructor c => GEnumParamSchema (C1 c U1) where
   genumParamSchema opts _ s = s
-    & type_ .~ SwaggerString
+    & type_ ?~ SwaggerString
     & enum_ %~ addEnumValue tag
     where
       tag = toJSON (constructorTagModifier opts (conName (Proxy3 :: Proxy3 c f p)))

--- a/src/Data/Swagger/Internal/Schema/Validation.hs
+++ b/src/Data/Swagger/Internal/Schema/Validation.hs
@@ -332,22 +332,35 @@ validateEnum value = do
 validateSchemaType :: Value -> Validation Schema ()
 validateSchemaType value = withSchema $ \sch ->
   case (sch ^. type_, value) of
-    (SwaggerNull,    Null)       -> valid
-    (SwaggerBoolean, Bool _)     -> valid
-    (SwaggerInteger, Number n)   -> sub_ paramSchema (validateInteger n)
-    (SwaggerNumber,  Number n)   -> sub_ paramSchema (validateNumber n)
-    (SwaggerString,  String s)   -> sub_ paramSchema (validateString s)
-    (SwaggerArray,   Array xs)   -> sub_ paramSchema (validateArray xs)
-    (SwaggerObject,  Object o)   -> validateObject o
+    (Just SwaggerNull,    Null)       -> valid
+    (Just SwaggerBoolean, Bool _)     -> valid
+    (Just SwaggerInteger, Number n)   -> sub_ paramSchema (validateInteger n)
+    (Just SwaggerNumber,  Number n)   -> sub_ paramSchema (validateNumber n)
+    (Just SwaggerString,  String s)   -> sub_ paramSchema (validateString s)
+    (Just SwaggerArray,   Array xs)   -> sub_ paramSchema (validateArray xs)
+    (Just SwaggerObject,  Object o)   -> validateObject o
+    (Nothing, Null)                   -> valid
+    (Nothing, Bool _)                 -> valid
+    -- Number by default
+    (Nothing, Number n)               -> sub_ paramSchema (validateNumber n)
+    (Nothing, String s)               -> sub_ paramSchema (validateString s)
+    (Nothing, Array xs)               -> sub_ paramSchema (validateArray xs)
+    (Nothing, Object o)               -> validateObject o
     (t, _) -> invalid $ "expected JSON value of type " ++ show t
 
 validateParamSchemaType :: Value -> Validation (ParamSchema t) ()
 validateParamSchemaType value = withSchema $ \sch ->
   case (sch ^. type_, value) of
-    (SwaggerBoolean, Bool _)     -> valid
-    (SwaggerInteger, Number n)   -> validateInteger n
-    (SwaggerNumber,  Number n)   -> validateNumber n
-    (SwaggerString,  String s)   -> validateString s
-    (SwaggerArray,   Array xs)   -> validateArray xs
+    (Just SwaggerBoolean, Bool _)     -> valid
+    (Just SwaggerInteger, Number n)   -> validateInteger n
+    (Just SwaggerNumber,  Number n)   -> validateNumber n
+    (Just SwaggerString,  String s)   -> validateString s
+    (Just SwaggerArray,   Array xs)   -> validateArray xs
+    (Nothing, Null)                   -> valid
+    (Nothing, Bool _)                 -> valid
+    -- Number by default
+    (Nothing, Number n)               -> validateNumber n
+    (Nothing, String s)               -> validateString s
+    (Nothing, Array xs)               -> validateArray xs
     (t, _) -> invalid $ "expected JSON value of type " ++ show t
 

--- a/src/Data/Swagger/Internal/Schema/Validation.hs
+++ b/src/Data/Swagger/Internal/Schema/Validation.hs
@@ -346,7 +346,7 @@ validateSchemaType value = withSchema $ \sch ->
     (Nothing, String s)               -> sub_ paramSchema (validateString s)
     (Nothing, Array xs)               -> sub_ paramSchema (validateArray xs)
     (Nothing, Object o)               -> validateObject o
-    (t, _) -> invalid $ "expected JSON value of type " ++ show t
+    param@(t, _) -> invalid $ "expected JSON value of type " ++ showType param
 
 validateParamSchemaType :: Value -> Validation (ParamSchema t) ()
 validateParamSchemaType value = withSchema $ \sch ->
@@ -356,11 +356,18 @@ validateParamSchemaType value = withSchema $ \sch ->
     (Just SwaggerNumber,  Number n)   -> validateNumber n
     (Just SwaggerString,  String s)   -> validateString s
     (Just SwaggerArray,   Array xs)   -> validateArray xs
-    (Nothing, Null)                   -> valid
     (Nothing, Bool _)                 -> valid
     -- Number by default
     (Nothing, Number n)               -> validateNumber n
     (Nothing, String s)               -> validateString s
     (Nothing, Array xs)               -> validateArray xs
-    (t, _) -> invalid $ "expected JSON value of type " ++ show t
+    param@(t, _) -> invalid $ "expected JSON value of type " ++ showType param
 
+showType :: (Maybe (SwaggerType t), Value) -> String
+showType (Just type_, _)     = show type_
+showType (Nothing, Null)     = "SwaggerNull"
+showType (Nothing, Bool _)   = "SwaggerBoolean"
+showType (Nothing, Number _) = "SwaggerNumber"
+showType (Nothing, String _) = "SwaggerString"
+showType (Nothing, Array _)  = "SwaggerArray"
+showType (Nothing, Object _) = "SwaggerObject"

--- a/src/Data/Swagger/Lens.hs
+++ b/src/Data/Swagger/Lens.hs
@@ -99,10 +99,10 @@ instance At   Operation where at n = responses . at n
 instance HasParamSchema NamedSchema (ParamSchema 'SwaggerKindSchema) where paramSchema = schema.paramSchema
 
 -- HasType instances
-instance HasType Header (SwaggerType ('SwaggerKindNormal Header)) where type_ = paramSchema.type_
-instance HasType Schema (SwaggerType 'SwaggerKindSchema) where type_ = paramSchema.type_
-instance HasType NamedSchema (SwaggerType 'SwaggerKindSchema) where type_ = paramSchema.type_
-instance HasType ParamOtherSchema (SwaggerType 'SwaggerKindParamOtherSchema) where type_ = paramSchema.type_
+instance HasType Header (Maybe (SwaggerType ('SwaggerKindNormal Header))) where type_ = paramSchema.type_
+instance HasType Schema (Maybe (SwaggerType 'SwaggerKindSchema)) where type_ = paramSchema.type_
+instance HasType NamedSchema (Maybe (SwaggerType 'SwaggerKindSchema)) where type_ = paramSchema.type_
+instance HasType ParamOtherSchema (Maybe (SwaggerType 'SwaggerKindParamOtherSchema)) where type_ = paramSchema.type_
 
 -- HasDefault instances
 instance HasDefault Header (Maybe Value) where default_ = paramSchema.default_

--- a/test/Data/Swagger/Schema/ValidationSpec.hs
+++ b/test/Data/Swagger/Schema/ValidationSpec.hs
@@ -248,7 +248,7 @@ instance ToJSON FreeForm where
 
 instance ToSchema FreeForm where
   declareNamedSchema _ = pure $ NamedSchema (Just $ T.pack "FreeForm") $ mempty
-    & type_ .~ SwaggerObject
+    & type_ ?~ SwaggerObject
     & additionalProperties ?~ AdditionalPropertiesAllowed True
 
 instance Arbitrary FreeForm where

--- a/test/Data/SwaggerSpec.hs
+++ b/test/Data/SwaggerSpec.hs
@@ -158,7 +158,7 @@ operationExample = mempty
     stringSchema :: ParamLocation -> ParamOtherSchema
     stringSchema loc = mempty
       & in_ .~ loc
-      & type_ .~ SwaggerString
+      & type_ ?~ SwaggerString
 
 operationExampleJSON :: Value
 operationExampleJSON = [aesonQQ|
@@ -224,7 +224,7 @@ operationExampleJSON = [aesonQQ|
 
 schemaPrimitiveExample :: Schema
 schemaPrimitiveExample = mempty
-  & type_  .~ SwaggerString
+  & type_  ?~ SwaggerString
   & format ?~ "email"
 
 schemaPrimitiveExampleJSON :: Value
@@ -237,14 +237,14 @@ schemaPrimitiveExampleJSON = [aesonQQ|
 
 schemaSimpleModelExample :: Schema
 schemaSimpleModelExample = mempty
-  & type_ .~ SwaggerObject
+  & type_ ?~ SwaggerObject
   & required .~ [ "name" ]
   & properties .~
-      [ ("name", Inline (mempty & type_ .~ SwaggerString))
+      [ ("name", Inline (mempty & type_ ?~ SwaggerString))
       , ("address", Ref (Reference "Address"))
       , ("age", Inline $ mempty
             & minimum_ ?~ 0
-            & type_    .~ SwaggerInteger
+            & type_    ?~ SwaggerInteger
             & format   ?~ "int32" ) ]
 
 schemaSimpleModelExampleJSON :: Value
@@ -272,8 +272,8 @@ schemaSimpleModelExampleJSON = [aesonQQ|
 
 schemaModelDictExample :: Schema
 schemaModelDictExample = mempty
-  & type_ .~ SwaggerObject
-  & additionalProperties ?~ AdditionalPropertiesSchema (Inline (mempty & type_ .~ SwaggerString))
+  & type_ ?~ SwaggerObject
+  & additionalProperties ?~ AdditionalPropertiesSchema (Inline (mempty & type_ ?~ SwaggerString))
 
 schemaModelDictExampleJSON :: Value
 schemaModelDictExampleJSON = [aesonQQ|
@@ -287,7 +287,7 @@ schemaModelDictExampleJSON = [aesonQQ|
 
 schemaAdditionalExample :: Schema
 schemaAdditionalExample = mempty
-  & type_ .~ SwaggerObject
+  & type_ ?~ SwaggerObject
   & additionalProperties ?~ AdditionalPropertiesAllowed True
 
 schemaAdditionalExampleJSON :: Value
@@ -300,13 +300,13 @@ schemaAdditionalExampleJSON = [aesonQQ|
 
 schemaWithExampleExample :: Schema
 schemaWithExampleExample = mempty
-  & type_ .~ SwaggerObject
+  & type_ ?~ SwaggerObject
   & properties .~
       [ ("id", Inline $ mempty
-            & type_  .~ SwaggerInteger
+            & type_  ?~ SwaggerInteger
             & format ?~ "int64" )
       , ("name", Inline $ mempty
-            & type_ .~ SwaggerString) ]
+            & type_ ?~ SwaggerString) ]
   & required .~ [ "name" ]
   & example ?~ [aesonQQ|
     {
@@ -345,19 +345,19 @@ schemaWithExampleExampleJSON = [aesonQQ|
 definitionsExample :: HashMap Text Schema
 definitionsExample =
   [ ("Category", mempty
-      & type_ .~ SwaggerObject
+      & type_ ?~ SwaggerObject
       & properties .~
           [ ("id", Inline $ mempty
-              & type_  .~ SwaggerInteger
+              & type_  ?~ SwaggerInteger
               & format ?~ "int64")
-          , ("name", Inline (mempty & type_ .~ SwaggerString)) ] )
+          , ("name", Inline (mempty & type_ ?~ SwaggerString)) ] )
   , ("Tag", mempty
-      & type_ .~ SwaggerObject
+      & type_ ?~ SwaggerObject
       & properties .~
           [ ("id", Inline $ mempty
-              & type_  .~ SwaggerInteger
+              & type_  ?~ SwaggerInteger
               & format ?~ "int64")
-          , ("name", Inline (mempty & type_ .~ SwaggerString)) ] ) ]
+          , ("name", Inline (mempty & type_ ?~ SwaggerString)) ] ) ]
 
 definitionsExampleJSON :: Value
 definitionsExampleJSON = [aesonQQ|
@@ -401,7 +401,7 @@ paramsDefinitionExample =
       & required ?~ True
       & schema .~ ParamOther (mempty
           & in_    .~ ParamQuery
-          & type_  .~ SwaggerInteger
+          & type_  ?~ SwaggerInteger
           & format ?~ "int32" ))
   , ("limitParam", mempty
       & name .~ "limit"
@@ -409,7 +409,7 @@ paramsDefinitionExample =
       & required ?~ True
       & schema .~ ParamOther (mempty
           & in_    .~ ParamQuery
-          & type_  .~ SwaggerInteger
+          & type_  ?~ SwaggerInteger
           & format ?~ "int32" )) ]
 
 paramsDefinitionExampleJSON :: Value
@@ -510,7 +510,7 @@ swaggerExample = mempty
       & at 200 ?~ Inline (mempty
           & description .~ "OK"
           & schema ?~ Inline (mempty
-              & type_ .~ SwaggerObject
+              & type_ ?~ SwaggerObject
               & example ?~ [aesonQQ|
                   {
                     "created": 100,
@@ -519,9 +519,9 @@ swaggerExample = mempty
               & description ?~ "This is some real Todo right here"
               & properties .~
                   [ ("created", Inline $ mempty
-                      & type_  .~ SwaggerInteger
+                      & type_  ?~ SwaggerInteger
                       & format ?~ "int32")
-                  , ("description", Inline (mempty & type_ .~ SwaggerString))]))
+                  , ("description", Inline (mempty & type_ ?~ SwaggerString))]))
       & produces ?~ MimeList [ "application/json" ]
       & parameters .~
           [ Inline $ mempty
@@ -530,7 +530,7 @@ swaggerExample = mempty
               & description ?~ "TodoId param"
               & schema .~ ParamOther (mempty
                   & in_ .~ ParamPath
-                  & type_ .~ SwaggerString ) ]
+                  & type_ ?~ SwaggerString ) ]
       & tags .~ Set.fromList [ "todo" ] ))
 
 swaggerExampleJSON :: Value
@@ -1632,14 +1632,14 @@ petstoreExampleJSON = [aesonQQ|
 
 compositionSchemaExample :: Schema
 compositionSchemaExample = mempty
-  & type_ .~ SwaggerObject
+  & type_ ?~ SwaggerObject
   & Data.Swagger.allOf ?~ [
       Ref (Reference "Other")
     , Inline (mempty
-             & type_ .~ SwaggerObject
+             & type_ ?~ SwaggerObject
              & properties .~
                   [ ("greet", Inline $ mempty
-                            & type_ .~ SwaggerString) ])
+                            & type_ ?~ SwaggerString) ])
   ]
 
 compositionSchemaExampleJSON :: Value


### PR DESCRIPTION
According to OpenAPI as it mentioned in #131, "type" might not be specified. It is implemented currently in Kubernetes. Thus, interface is changing with this fix. 