### PR TITLE
Make nullary schemas valid

### DIFF
--- a/test/Data/Swagger/CommonTestTypes.hs
+++ b/test/Data/Swagger/CommonTestTypes.hs
@@ -552,7 +552,7 @@ lightSchemaJSON = [aesonQQ|
   "type": "object",
   "properties":
     {
-      "NoLight": { "type": "array", "items": [] },
+      "NoLight": { "type": "array", "items": {}, "maxItems": 0, "example": [] },
       "LightFreq": { "type": "number", "format": "double" },
       "LightColor": { "$ref": "#/definitions/Color" },
       "LightWaveLength": { "type": "number", "format": "double" }
@@ -568,7 +568,7 @@ lightInlinedSchemaJSON = [aesonQQ|
   "type": "object",
   "properties":
     {
-      "NoLight": { "type": "array", "items": [] },
+      "NoLight": { "type": "array", "items": {}, "maxItems": 0, "example": [] },
       "LightFreq": { "type": "number", "format": "double" },
       "LightColor":
         {


### PR DESCRIPTION
Resolves #167 

Because of `toJSON · fromJSON ≠ ±id` for `SwaggerItems`, I had to modify `instance ToJSON Schema` to make tests pass… (+ we don’t have lens here yet).

Ugly…

/cc @phadej @fizruk 