### PR TITLE
Fix #138 schema type becomes optional: rebase

### DIFF
--- a/examples/hackage.hs
+++ b/examples/hackage.hs
@@ -27,7 +27,7 @@ instance ToSchema UserSummary where
     usernameSchema <- declareSchemaRef (Proxy :: Proxy Username)
     useridSchema   <- declareSchemaRef (Proxy :: Proxy Int)
     return $ NamedSchema (Just "UserSummary") $ mempty
-      & type_ .~ SwaggerObject
+      & type_ ?~ SwaggerObject
       & properties .~
           [ ("summaryUsername", usernameSchema )
           , ("summaryUserid"  , useridSchema   )

--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -610,7 +610,7 @@ data ParamSchema (t :: SwaggerKind *) = ParamSchema
   , _paramSchemaMultipleOf :: Maybe Scientific
   } deriving (Eq, Show, Generic, Typeable)
 
-deriving instance (Typeable k, Data (SwaggerType k), Data (SwaggerItems k)) => Data (ParamSchema k)
+deriving instance (Typeable k, Data (Maybe (SwaggerType k)), Data (SwaggerItems k)) => Data (ParamSchema k)
 
 data Xml = Xml
   { -- | Replaces the name of the element/attribute used for the described schema property.

--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -335,7 +335,7 @@ sketchSchema = sketch . toJSON
 
     go Null       = mempty & type_ ?~ SwaggerNull
     go (Bool _)   = mempty & type_ ?~ SwaggerBoolean
-    go (String _) = mempty & type_   ?~ SwaggerString
+    go (String _) = mempty & type_ ?~ SwaggerString
     go (Number _) = mempty & type_ ?~ SwaggerNumber
     go (Array xs) = mempty
       & type_   ?~ SwaggerArray


### PR DESCRIPTION
According to OpenAPI as it mentioned in #131, "type" might not be specified. It is implemented currently in Kubernetes. Thus, interface is changing with this fix. CHANGELOG should be also updated.

---

I think some tests **should** fail, as I removed `inferSchemaTypes`...