### PR TITLE
Remove instance for deprecated list monad transformer.

### DIFF
--- a/src/Data/Swagger/Declare.hs
+++ b/src/Data/Swagger/Declare.hs
@@ -162,10 +162,6 @@ instance MonadDeclare d m => MonadDeclare d (IdentityT m) where
   declare = lift . declare
   look = lift look
 
-instance MonadDeclare d m => MonadDeclare d (ListT m) where
-  declare = lift . declare
-  look = lift look
-
 instance MonadDeclare d m => MonadDeclare d (MaybeT m) where
   declare = lift . declare
   look = lift look


### PR DESCRIPTION
This addresses the following warning:

```
swagger2                 > /tmp/stack8404/swagger2-2.4/src/Data/Swagger/Declare.hs:165:46: warning: [-Wdeprecations]
swagger2                 >     In the use of type constructor or class ‘ListT’
swagger2                 >     (imported from Control.Monad.List, but defined in Control.Monad.Trans.List):
swagger2                 >     Deprecated: "This transformer is invalid on most monads"
swagger2                 >     |
swagger2                 > 165 | instance MonadDeclare d m => MonadDeclare d (ListT m) where
swagger2                 >     |                                              ^^^^^
swagger2                 > [ 2 of 16] Compiling Data.Swagger.Internal.AesonUtils
```

The `transformers` package has deprecated the `ListT` transformers, and has given a good reason for that.

If somebody insists on using it for their API, they can define an orphan instance, which is not a good, but it's better for them to have two problems (a big one with the instance almost certainly being broken, and a smaller one with the instance being orphan), then for everybody to have the bigger problem.