### PR TITLE
Add support for optics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.5.20190908
+# version: 0.5.20191020
 #
 language: c
 dist: xenial
@@ -39,10 +39,6 @@ matrix:
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.2.2","cabal-install-3.0"]}}
     - compiler: ghc-8.0.2
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.0.2","cabal-install-3.0"]}}
-    - compiler: ghc-7.10.3
-      addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-7.10.3","cabal-install-3.0"]}}
-    - compiler: ghc-7.8.4
-      addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-7.8.4","cabal-install-3.0"]}}
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')
   - WITHCOMPILER="-w $HC"
@@ -83,21 +79,29 @@ install:
   - HEADHACKAGE=false
   - rm -f $CABALHOME/config
   - |
-    echo "verbose: normal +nowrap +markoutput"          >> $CABALHOME/config
-    echo "remote-build-reporting: anonymous"            >> $CABALHOME/config
-    echo "write-ghc-environment-files: always"          >> $CABALHOME/config
-    echo "remote-repo-cache: $CABALHOME/packages"       >> $CABALHOME/config
-    echo "logs-dir:          $CABALHOME/logs"           >> $CABALHOME/config
-    echo "world-file:        $CABALHOME/world"          >> $CABALHOME/config
-    echo "extra-prog-path:   $CABALHOME/bin"            >> $CABALHOME/config
-    echo "symlink-bindir:    $CABALHOME/bin"            >> $CABALHOME/config
-    echo "installdir:        $CABALHOME/bin"            >> $CABALHOME/config
-    echo "build-summary:     $CABALHOME/logs/build.log" >> $CABALHOME/config
-    echo "store-dir:         $CABALHOME/store"          >> $CABALHOME/config
-    echo "install-dirs user"                            >> $CABALHOME/config
-    echo "  prefix: $CABALHOME"                         >> $CABALHOME/config
-    echo "repository hackage.haskell.org"               >> $CABALHOME/config
-    echo "  url: http://hackage.haskell.org/"           >> $CABALHOME/config
+    echo "verbose: normal +nowrap +markoutput"                                  >> $CABALHOME/config
+    echo "remote-build-reporting: anonymous"                                    >> $CABALHOME/config
+    echo "write-ghc-environment-files: always"                                  >> $CABALHOME/config
+    echo "remote-repo-cache: $CABALHOME/packages"                               >> $CABALHOME/config
+    echo "logs-dir:          $CABALHOME/logs"                                   >> $CABALHOME/config
+    echo "world-file:        $CABALHOME/world"                                  >> $CABALHOME/config
+    echo "extra-prog-path:   $CABALHOME/bin"                                    >> $CABALHOME/config
+    echo "symlink-bindir:    $CABALHOME/bin"                                    >> $CABALHOME/config
+    echo "installdir:        $CABALHOME/bin"                                    >> $CABALHOME/config
+    echo "build-summary:     $CABALHOME/logs/build.log"                         >> $CABALHOME/config
+    echo "store-dir:         $CABALHOME/store"                                  >> $CABALHOME/config
+    echo "install-dirs user"                                                    >> $CABALHOME/config
+    echo "  prefix: $CABALHOME"                                                 >> $CABALHOME/config
+    echo "repository hackage.haskell.org"                                       >> $CABALHOME/config
+    echo "  url: http://hackage.haskell.org/"                                   >> $CABALHOME/config
+    echo "  secure: True"                                                       >> $CABALHOME/config
+    echo "  key-threshold: 3"                                                   >> $CABALHOME/config
+    echo "  root-keys:"                                                         >> $CABALHOME/config
+    echo "    fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0" >> $CABALHOME/config
+    echo "    1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42" >> $CABALHOME/config
+    echo "    2c6c3627bd6c982990239487f1abd02e08a02e6cf16edb105a8012d444d870c3" >> $CABALHOME/config
+    echo "    0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d" >> $CABALHOME/config
+    echo "    51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921" >> $CABALHOME/config
   - |
     echo "program-default-options"                >> $CABALHOME/config
     echo "  ghc-options: $GHCJOBS +RTS -M6G -RTS" >> $CABALHOME/config
@@ -154,5 +158,5 @@ script:
   - rm -f cabal.project.local
   - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks all | color_cabal_output
 
-# REGENDATA ["--branches","master","--haddock-jobs=>=8.4","--output",".travis.yml","swagger2.cabal"]
+# REGENDATA ("0.5.20191020",["--branches","master","--haddock-jobs=>=8.4","--output",".travis.yml","swagger2.cabal"])
 # EOF

--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -31,6 +31,7 @@ module Data.Swagger (
 
   -- * Re-exports
   module Data.Swagger.Lens,
+  module Data.Swagger.Optics,
   module Data.Swagger.Operation,
   module Data.Swagger.ParamSchema,
   module Data.Swagger.Schema,
@@ -112,6 +113,7 @@ module Data.Swagger (
 ) where
 
 import Data.Swagger.Lens
+import Data.Swagger.Optics ()
 import Data.Swagger.Operation
 import Data.Swagger.ParamSchema
 import Data.Swagger.Schema
@@ -174,6 +176,8 @@ import Data.Swagger.Internal
 -- @
 
 -- $lens
+--
+-- Note: if you're working with the <https://hackage.haskell.org/package/optics optics> library, take a look at "Data.Swagger.Optics".
 --
 -- Since @'Swagger'@ has a fairly complex structure, lenses and prisms are used
 -- to work comfortably with it. In combination with @'Monoid'@ instances, lenses

--- a/src/Data/Swagger/Optics.hs
+++ b/src/Data/Swagger/Optics.hs
@@ -1,0 +1,597 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+-- |
+-- Module:      Data.Swagger.Optics
+-- Maintainer:  Andrzej Rybczak <andrzej@rybczak.net>
+-- Stability:   experimental
+--
+-- Lenses and prisms for the <https://hackage.haskell.org/package/optics optics>
+-- library.
+--
+-- >>> import Data.Aeson
+-- >>> import Optics.Core
+-- >>> :set -XOverloadedLabels
+--
+-- Example from the "Data.Swagger" module using @optics@:
+--
+-- >>> :{
+-- encode $ (mempty :: Swagger)
+--   & #definitions .~ [ ("User", mempty & #type ?~ SwaggerString) ]
+--   & #paths .~
+--     [ ("/user", mempty & #get ?~ (mempty
+--         & #produces ?~ MimeList ["application/json"]
+--         & at 200 ?~ ("OK" & #_Inline % #schema ?~ Ref (Reference "User"))
+--         & at 404 ?~ "User info not found")) ]
+-- :}
+-- "{\"swagger\":\"2.0\",\"info\":{\"version\":\"\",\"title\":\"\"},\"paths\":{\"/user\":{\"get\":{\"produces\":[\"application/json\"],\"responses\":{\"404\":{\"description\":\"User info not found\"},\"200\":{\"schema\":{\"$ref\":\"#/definitions/User\"},\"description\":\"OK\"}}}}},\"definitions\":{\"User\":{\"type\":\"string\"}}}"
+--
+-- For convenience optics are defined as /labels/. It means that field accessor
+-- names can be overloaded for different types. One such common field is
+-- @#description@. Many components of a Swagger specification can have
+-- descriptions, and you can use the same name for them:
+--
+-- >>> encode $ (mempty :: Response) & #description .~ "No content"
+-- "{\"description\":\"No content\"}"
+-- >>> :{
+-- encode $ (mempty :: Schema)
+--   & #type        ?~ SwaggerBoolean
+--   & #description ?~ "To be or not to be"
+-- :}
+-- "{\"description\":\"To be or not to be\",\"type\":\"boolean\"}"
+--
+-- @'ParamSchema'@ is basically the /base schema specification/ and many types
+-- contain it. So for convenience, all @'ParamSchema'@ fields are transitively
+-- made fields of the type that has it. For example, you can use @#type@ to
+-- access @'SwaggerType'@ of @'Header'@ schema without having to use
+-- @#paramSchema@:
+--
+-- >>> encode $ (mempty :: Header) & #type ?~ SwaggerNumber
+-- "{\"type\":\"number\"}"
+--
+-- Additionally, to simplify working with @'Response'@, both @'Operation'@ and
+-- @'Responses'@ have direct access to it via @'Optics.Core.At.at'@. Example:
+--
+-- >>> :{
+-- encode $ (mempty :: Operation)
+--   & at 404 ?~ "Not found"
+-- :}
+-- "{\"responses\":{\"404\":{\"description\":\"Not found\"}}}"
+--
+module Data.Swagger.Optics () where
+
+import Data.Aeson (Value)
+import Data.Scientific (Scientific)
+import Data.Swagger.Internal
+import Data.Text (Text)
+import Optics.Core
+import Optics.TH
+
+-- Lenses
+
+makeFieldLabels ''Swagger
+makeFieldLabels ''Host
+makeFieldLabels ''Info
+makeFieldLabels ''Contact
+makeFieldLabels ''License
+makeFieldLabels ''PathItem
+makeFieldLabels ''Tag
+makeFieldLabels ''Operation
+makeFieldLabels ''Param
+makeFieldLabels ''ParamOtherSchema
+makeFieldLabels ''Header
+makeFieldLabels ''Schema
+makeFieldLabels ''NamedSchema
+makeFieldLabels ''ParamSchema
+makeFieldLabels ''Xml
+makeFieldLabels ''Responses
+makeFieldLabels ''Response
+makeFieldLabels ''SecurityScheme
+makeFieldLabels ''ApiKeyParams
+makeFieldLabels ''OAuth2Params
+makeFieldLabels ''ExternalDocs
+
+-- Prisms
+
+makePrismLabels ''ParamAnySchema
+makePrismLabels ''SecuritySchemeType
+makePrismLabels ''Referenced
+
+-- SwaggerItems prisms
+
+instance
+  ( a ~ [Referenced Schema]
+  , b ~ [Referenced Schema]
+  ) => LabelOptic "_SwaggerItemsArray"
+         A_Review
+         (SwaggerItems 'SwaggerKindSchema)
+         (SwaggerItems 'SwaggerKindSchema)
+         a
+         b where
+  labelOptic = unto (\x -> SwaggerItemsArray x)
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Referenced Schema
+  , b ~ Referenced Schema
+  ) => LabelOptic "_SwaggerItemsObject"
+         A_Review
+         (SwaggerItems 'SwaggerKindSchema)
+         (SwaggerItems 'SwaggerKindSchema)
+         a
+         b where
+  labelOptic = unto (\x -> SwaggerItemsObject x)
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ (Maybe (CollectionFormat t), ParamSchema t)
+  , b ~ (Maybe (CollectionFormat t), ParamSchema t)
+  ) => LabelOptic "_SwaggerItemsPrimitive"
+         A_Review
+         (SwaggerItems t)
+         (SwaggerItems t)
+         a
+         b where
+  labelOptic = unto (\(c, p) -> SwaggerItemsPrimitive c p)
+  {-# INLINE labelOptic #-}
+
+-- =============================================================
+-- More helpful instances for easier access to schema properties
+
+type instance Index Responses = HttpStatusCode
+type instance Index Operation = HttpStatusCode
+
+type instance IxValue Responses = Referenced Response
+type instance IxValue Operation = Referenced Response
+
+instance Ixed Responses where
+  ix n = #responses % ix n
+  {-# INLINE ix #-}
+instance At   Responses where
+  at n = #responses % at n
+  {-# INLINE at #-}
+
+instance Ixed Operation where
+  ix n = #responses % ix n
+  {-# INLINE ix #-}
+instance At   Operation where
+  at n = #responses % at n
+  {-# INLINE at #-}
+
+-- #paramSchema
+
+instance
+  ( a ~ ParamSchema 'SwaggerKindSchema
+  , b ~ ParamSchema 'SwaggerKindSchema
+  ) => LabelOptic "paramSchema" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #schema % #paramSchema
+  {-# INLINE labelOptic #-}
+
+-- #type
+
+instance
+  ( a ~ Maybe (SwaggerType ('SwaggerKindNormal Header))
+  , b ~ Maybe (SwaggerType ('SwaggerKindNormal Header))
+  ) => LabelOptic "type" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #type
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe (SwaggerType 'SwaggerKindSchema)
+  , b ~ Maybe (SwaggerType 'SwaggerKindSchema)
+  ) => LabelOptic "type" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #type
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe (SwaggerType 'SwaggerKindSchema)
+  , b ~ Maybe (SwaggerType 'SwaggerKindSchema)
+  ) => LabelOptic "type" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #type
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe (SwaggerType 'SwaggerKindParamOtherSchema)
+  , b ~ Maybe (SwaggerType 'SwaggerKindParamOtherSchema)
+  ) => LabelOptic "type" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #type
+  {-# INLINE labelOptic #-}
+
+-- #default
+
+instance
+  ( a ~ Maybe Value, b ~ Maybe Value
+  ) => LabelOptic "default" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #default
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Value, b ~ Maybe Value
+  ) => LabelOptic "default" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #default
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Value, b ~ Maybe Value
+  ) => LabelOptic "default" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #default
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Value, b ~ Maybe Value
+  ) => LabelOptic "default" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #default
+  {-# INLINE labelOptic #-}
+
+-- #format
+
+instance
+  ( a ~ Maybe Format, b ~ Maybe Format
+  ) => LabelOptic "format" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #format
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Format, b ~ Maybe Format
+  ) => LabelOptic "format" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #format
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Format, b ~ Maybe Format
+  ) => LabelOptic "format" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #format
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Format, b ~ Maybe Format
+  ) => LabelOptic "format" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #format
+  {-# INLINE labelOptic #-}
+
+-- #items
+
+instance
+  ( a ~ Maybe (SwaggerItems ('SwaggerKindNormal Header))
+  , b ~ Maybe (SwaggerItems ('SwaggerKindNormal Header))
+  ) => LabelOptic "items" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #items
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe (SwaggerItems 'SwaggerKindSchema)
+  , b ~ Maybe (SwaggerItems 'SwaggerKindSchema)
+  ) => LabelOptic "items" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #items
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe (SwaggerItems 'SwaggerKindSchema)
+  , b ~ Maybe (SwaggerItems 'SwaggerKindSchema)
+  ) => LabelOptic "items" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #items
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe (SwaggerItems 'SwaggerKindParamOtherSchema)
+  , b ~ Maybe (SwaggerItems 'SwaggerKindParamOtherSchema)
+  ) => LabelOptic "items" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #items
+  {-# INLINE labelOptic #-}
+
+-- #maximum
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "maximum" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #maximum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "maximum" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #maximum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "maximum" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #maximum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "maximum" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #maximum
+  {-# INLINE labelOptic #-}
+
+-- #exclusiveMaximum
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "exclusiveMaximum" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #exclusiveMaximum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "exclusiveMaximum" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #exclusiveMaximum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "exclusiveMaximum" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #exclusiveMaximum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "exclusiveMaximum" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #exclusiveMaximum
+  {-# INLINE labelOptic #-}
+
+-- #minimum
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "minimum" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #minimum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "minimum" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #minimum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "minimum" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #minimum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "minimum" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #minimum
+  {-# INLINE labelOptic #-}
+
+-- #exclusiveMinimum
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "exclusiveMinimum" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #exclusiveMinimum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "exclusiveMinimum" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #exclusiveMinimum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "exclusiveMinimum" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #exclusiveMinimum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "exclusiveMinimum" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #exclusiveMinimum
+  {-# INLINE labelOptic #-}
+
+-- #maxLength
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "maxLength" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #maxLength
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "maxLength" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #maxLength
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "maxLength" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #maxLength
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "maxLength" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #maxLength
+  {-# INLINE labelOptic #-}
+
+-- #minLength
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "minLength" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #minLength
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "minLength" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #minLength
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "minLength" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #minLength
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "minLength" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #minLength
+  {-# INLINE labelOptic #-}
+
+-- #pattern
+
+instance
+  ( a ~ Maybe Text, b ~ Maybe Text
+  ) => LabelOptic "pattern" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #pattern
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Text, b ~ Maybe Text
+  ) => LabelOptic "pattern" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #pattern
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Text, b ~ Maybe Text
+  ) => LabelOptic "pattern" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #pattern
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Text, b ~ Maybe Text
+  ) => LabelOptic "pattern" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #pattern
+  {-# INLINE labelOptic #-}
+
+-- #maxItems
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "maxItems" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #maxItems
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "maxItems" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #maxItems
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "maxItems" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #maxItems
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "maxItems" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #maxItems
+  {-# INLINE labelOptic #-}
+
+-- #minItems
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "minItems" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #minItems
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "minItems" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #minItems
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "minItems" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #minItems
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Integer, b ~ Maybe Integer
+  ) => LabelOptic "minItems" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #minItems
+  {-# INLINE labelOptic #-}
+
+-- #uniqueItems
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "uniqueItems" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #uniqueItems
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "uniqueItems" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #uniqueItems
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "uniqueItems" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #uniqueItems
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Bool, b ~ Maybe Bool
+  ) => LabelOptic "uniqueItems" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #uniqueItems
+  {-# INLINE labelOptic #-}
+
+-- #enum
+
+instance
+  ( a ~ Maybe [Value], b ~ Maybe [Value]
+  ) => LabelOptic "enum" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #enum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe [Value], b ~ Maybe [Value]
+  ) => LabelOptic "enum" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #enum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe [Value], b ~ Maybe [Value]
+  ) => LabelOptic "enum" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #enum
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe [Value], b ~ Maybe [Value]
+  ) => LabelOptic "enum" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #enum
+  {-# INLINE labelOptic #-}
+
+-- #multipleOf
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "multipleOf" A_Lens Header Header a b where
+  labelOptic = #paramSchema % #multipleOf
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "multipleOf" A_Lens Schema Schema a b where
+  labelOptic = #paramSchema % #multipleOf
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "multipleOf" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #paramSchema % #multipleOf
+  {-# INLINE labelOptic #-}
+
+instance
+  ( a ~ Maybe Scientific, b ~ Maybe Scientific
+  ) => LabelOptic "multipleOf" A_Lens ParamOtherSchema ParamOtherSchema a b where
+  labelOptic = #paramSchema % #multipleOf
+  {-# INLINE labelOptic #-}

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -25,9 +25,7 @@ extra-source-files:
   , examples/*.hs
   , include/overlapping-compat.h
 tested-with:
-  GHC ==7.8.4
-   || ==7.10.3
-   || ==8.0.2
+  GHC ==8.0.2
    || ==8.2.2
    || ==8.4.4
    || ==8.6.5
@@ -45,6 +43,7 @@ library
     Data.Swagger.Declare
     Data.Swagger.Lens
     Data.Swagger.Operation
+    Data.Swagger.Optics
     Data.Swagger.ParamSchema
     Data.Swagger.Schema
     Data.Swagger.Schema.Generator
@@ -62,7 +61,7 @@ library
 
   -- GHC boot libraries
   build-depends:
-      base             >=4.7      && <4.14
+      base             >=4.9      && <4.14
     , aeson-pretty     >=0.8.7    && <0.9
     , bytestring       >=0.10.4.0 && <0.11
     , containers       >=0.5.5.1  && <0.7
@@ -83,9 +82,11 @@ library
     , generics-sop              >=0.3.2.0  && <0.6
     , hashable                  >=1.2.7.0  && <1.4
     , http-media                >=0.7.1.2  && <0.9
-    , insert-ordered-containers >=0.2.2    && <0.3
+    , insert-ordered-containers >=0.2.3    && <0.3
     , lens                      >=4.16.1   && <4.19
     , network                   >=2.6.3.5  && <3.2
+    , optics-core               >=0.2      && <0.3
+    , optics-th                 >=0.2      && <0.3
     , scientific                >=0.3.6.2  && <0.4
     , transformers-compat       >=0.3      && <0.7
     , unordered-containers      >=0.2.9.0  && <0.3


### PR DESCRIPTION
PR adds support for using `optics` library instead of `lens` as an alternative. There are no name clashes because `optics` supports lenses/prisms as labels.

cc @phadej 

EDIT: Travis doesn't pick up `insert-ordered-containers` from the `cabal.project` file :thinking: 