### PR TITLE
Release v2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+2.5
+---
+
+Highlights:
+- Add instance for `TimeOfDay` (see [#196]( https://github.com/GetShopTV/swagger2/pull/196 ));
+- Add support for [`optics`](https://hackage.haskell.org/package/optics) (see [#200]( https://github.com/GetShopTV/swagger2/pull/200 ));
+- Slightly better validation errors (see [#195]( https://github.com/GetShopTV/swagger2/pull/195 ));
+
+Fixes and minor changes:
+- Minor cleanup (see [#194]( https://github.com/GetShopTV/swagger2/pull/194 ));
+- Allow base-4.13 and other GHC-8.8 related stuff (see [#198]( https://github.com/GetShopTV/swagger2/pull/198 ));
+- Fix `stack.yaml` (see [#201]( https://github.com/GetShopTV/swagger2/pull/201 ));
+
 2.4
 ---
 

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -1,7 +1,6 @@
 cabal-version:       >=1.10
 name:                swagger2
 version:             2.5
-x-revision:          1
 
 synopsis:            Swagger 2.0 data model
 category:            Web, Swagger

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                swagger2
-version:             2.4
+version:             2.5
 x-revision:          1
 
 synopsis:            Swagger 2.0 data model


### PR DESCRIPTION
Highlights:
- Add instance for `TimeOfDay` (see [#196]( https://github.com/GetShopTV/swagger2/pull/196 ));
- Add support for [`optics`](https://hackage.haskell.org/package/optics) (see [#200]( https://github.com/GetShopTV/swagger2/pull/200 ));
- Slightly better validation errors (see [#195]( https://github.com/GetShopTV/swagger2/pull/195 ));

Fixes and minor changes:
- Minor cleanup (see [#194]( https://github.com/GetShopTV/swagger2/pull/194 ));
- Allow base-4.13 and other GHC-8.8 related stuff (see [#198]( https://github.com/GetShopTV/swagger2/pull/198 ));
- Fix `stack.yaml` (see [#201]( https://github.com/GetShopTV/swagger2/pull/201 ));
