### PR TITLE
Move aeson-pretty to other dependencies

### DIFF
--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -61,7 +61,6 @@ library
   -- GHC boot libraries
   build-depends:
       base             >=4.9      && <4.14
-    , aeson-pretty     >=0.8.7    && <0.9
     , bytestring       >=0.10.4.0 && <0.11
     , containers       >=0.5.5.1  && <0.7
     , template-haskell >=2.9.0.0  && <2.16
@@ -76,6 +75,7 @@ library
   build-depends:
       base-compat-batteries     >=0.10.4   && <0.12
     , aeson                     >=1.4.2.0  && <1.5
+    , aeson-pretty              >=0.8.7    && <0.9
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint
     , cookie                    >=0.4.3    && <0.5
     , generics-sop              >=0.3.2.0  && <0.6


### PR DESCRIPTION
It's not a GHC boot library.