### PR TITLE
GHC 8.10 support

### DIFF
--- a/src/Data/Swagger/Declare.hs
+++ b/src/Data/Swagger/Declare.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DeriveFunctor          #-}
+{-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE UndecidableInstances   #-}
 -- |
 -- Module:      Data.Swagger.Declare
 -- Maintainer:  Nickolay Kudasov <nickolay@getshoptv.com>
@@ -11,24 +11,24 @@
 -- Declare monad transformer and associated functions.
 module Data.Swagger.Declare where
 
-import Prelude ()
-import Prelude.Compat
+import           Prelude                           ()
+import           Prelude.Compat
 
-import Control.Monad
-import Control.Monad.Cont (ContT)
-import Control.Monad.List (ListT)
-import Control.Monad.Reader (ReaderT)
-import Control.Monad.Trans
-import Control.Monad.Trans.Except (ExceptT)
-import Control.Monad.Trans.Identity (IdentityT)
-import Control.Monad.Trans.Maybe (MaybeT)
-import Control.Monad.Trans.State.Lazy as Lazy
-import Control.Monad.Trans.State.Strict as Strict
-import Control.Monad.Trans.RWS.Lazy as Lazy
-import Control.Monad.Trans.RWS.Strict as Strict
-import Control.Monad.Trans.Writer.Lazy as Lazy
-import Control.Monad.Trans.Writer.Strict as Strict
-import Data.Functor.Identity
+import           Control.Monad
+import           Control.Monad.Cont                (ContT)
+import           Control.Monad.List                (ListT)
+import           Control.Monad.Reader              (ReaderT)
+import           Control.Monad.Trans
+import           Control.Monad.Trans.Except        (ExceptT)
+import           Control.Monad.Trans.Identity      (IdentityT)
+import           Control.Monad.Trans.Maybe         (MaybeT)
+import           Control.Monad.Trans.RWS.Lazy      as Lazy
+import           Control.Monad.Trans.RWS.Strict    as Strict
+import           Control.Monad.Trans.State.Lazy    as Lazy
+import           Control.Monad.Trans.State.Strict  as Strict
+import           Control.Monad.Trans.Writer.Lazy   as Lazy
+import           Control.Monad.Trans.Writer.Strict as Strict
+import           Data.Functor.Identity
 
 -- | A declare monad transformer parametrized by:
 --
@@ -159,10 +159,6 @@ instance MonadDeclare d m => MonadDeclare d (ExceptT e m) where
   look = lift look
 
 instance MonadDeclare d m => MonadDeclare d (IdentityT m) where
-  declare = lift . declare
-  look = lift look
-
-instance MonadDeclare d m => MonadDeclare d (ListT m) where
   declare = lift . declare
   look = lift look
 

--- a/src/Data/Swagger/Declare.hs
+++ b/src/Data/Swagger/Declare.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DeriveFunctor          #-}
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
-{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- |
 -- Module:      Data.Swagger.Declare
 -- Maintainer:  Nickolay Kudasov <nickolay@getshoptv.com>
@@ -11,24 +11,24 @@
 -- Declare monad transformer and associated functions.
 module Data.Swagger.Declare where
 
-import           Prelude                           ()
-import           Prelude.Compat
+import Prelude ()
+import Prelude.Compat
 
-import           Control.Monad
-import           Control.Monad.Cont                (ContT)
-import           Control.Monad.List                (ListT)
-import           Control.Monad.Reader              (ReaderT)
-import           Control.Monad.Trans
-import           Control.Monad.Trans.Except        (ExceptT)
-import           Control.Monad.Trans.Identity      (IdentityT)
-import           Control.Monad.Trans.Maybe         (MaybeT)
-import           Control.Monad.Trans.RWS.Lazy      as Lazy
-import           Control.Monad.Trans.RWS.Strict    as Strict
-import           Control.Monad.Trans.State.Lazy    as Lazy
-import           Control.Monad.Trans.State.Strict  as Strict
-import           Control.Monad.Trans.Writer.Lazy   as Lazy
-import           Control.Monad.Trans.Writer.Strict as Strict
-import           Data.Functor.Identity
+import Control.Monad
+import Control.Monad.Cont (ContT)
+import Control.Monad.List (ListT)
+import Control.Monad.Reader (ReaderT)
+import Control.Monad.Trans
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Identity (IdentityT)
+import Control.Monad.Trans.Maybe (MaybeT)
+import Control.Monad.Trans.State.Lazy as Lazy
+import Control.Monad.Trans.State.Strict as Strict
+import Control.Monad.Trans.RWS.Lazy as Lazy
+import Control.Monad.Trans.RWS.Strict as Strict
+import Control.Monad.Trans.Writer.Lazy as Lazy
+import Control.Monad.Trans.Writer.Strict as Strict
+import Data.Functor.Identity
 
 -- | A declare monad transformer parametrized by:
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,9 @@
-resolver: lts-14.3
+resolver: lts-15.1
 packages:
 - '.'
 extra-deps:
-- optics-core-0.2
-- optics-th-0.2
-- optics-extra-0.2
+- optics-core-0.3
+- optics-th-0.3
+- optics-extra-0.3
 - indexed-profunctors-0.1
-- insert-ordered-containers-0.2.3
+- insert-ordered-containers-0.2.3.1

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -29,6 +29,7 @@ tested-with:
    || ==8.4.4
    || ==8.6.5
    || ==8.8.1
+   || ==8.10.1
 
 custom-setup
   setup-depends:
@@ -60,10 +61,10 @@ library
 
   -- GHC boot libraries
   build-depends:
-      base             >=4.9      && <4.14
+      base             >=4.9      && <4.15
     , bytestring       >=0.10.4.0 && <0.11
     , containers       >=0.5.5.1  && <0.7
-    , template-haskell >=2.9.0.0  && <2.16
+    , template-haskell >=2.9.0.0  && <2.17
     , time             >=1.4.2    && <1.10
     , transformers     >=0.3.0.0  && <0.6
 
@@ -82,10 +83,10 @@ library
     , hashable                  >=1.2.7.0  && <1.4
     , http-media                >=0.7.1.2  && <0.9
     , insert-ordered-containers >=0.2.3    && <0.3
-    , lens                      >=4.16.1   && <4.19
+    , lens                      >=4.16.1   && <4.20
     , network                   >=2.6.3.5  && <3.2
-    , optics-core               >=0.2      && <0.3
-    , optics-th                 >=0.2      && <0.3
+    , optics-core               >=0.2      && <0.4
+    , optics-th                 >=0.2      && <0.4
     , scientific                >=0.3.6.2  && <0.4
     , transformers-compat       >=0.3      && <0.7
     , unordered-containers      >=0.2.9.0  && <0.3


### PR DESCRIPTION
Hi @fisx, @phadej,

This PR intended to close #208.

## Details

- Relax boundaries to allow build with GHC 8.10.1.
- Bump LTS to enable build via stack with GHC 8.8.1 by default.
- Resolve test fail: 
  ```
  Test suite doctests: RUNNING...
  
  ./swagger2/src/Data/Swagger/Declare.hs:165:46: warning: [-Wdeprecations]
      In the use of type constructor or class ‘ListT’
      (imported from Control.Monad.List, but defined in Control.Monad.Trans.List):
      Deprecated: "This transformer is invalid on most monads"
      |
  165 | instance MonadDeclare d m => MonadDeclare d (ListT m) where
      |                                              ^^^^^
  Test suite doctests: FAIL
  ```

I have enabled `stylish-haskell` by default. If you disagree with auto-formatting, I will undo formatting changes.

Thanks,
@swamp-agr 