### PR TITLE
OpenAPI 3

### DIFF
--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -1257,11 +1257,10 @@ referencedToJSON :: ToJSON a => Text -> Referenced a -> Value
 referencedToJSON prefix (Ref (Reference ref)) = object [ "$ref" .= (prefix <> ref) ]
 referencedToJSON _ (Inline x) = toJSON x
 
--- FIXME this stuff
-instance ToJSON (Referenced Schema)   where toJSON = referencedToJSON "#/definitions/"
-instance ToJSON (Referenced Param)    where toJSON = referencedToJSON "#/parameters/"
-instance ToJSON (Referenced Response) where toJSON = referencedToJSON "#/responses/"
-instance ToJSON (Referenced RequestBody) where toJSON = referencedToJSON "#/!!!!/"
+instance ToJSON (Referenced Schema)   where toJSON = referencedToJSON "#/components/schemas/"
+instance ToJSON (Referenced Param)    where toJSON = referencedToJSON "#/components/parameters/"
+instance ToJSON (Referenced Response) where toJSON = referencedToJSON "#/components/responses/"
+instance ToJSON (Referenced RequestBody) where toJSON = referencedToJSON "#/components/requestBodies/"
 
 instance ToJSON (SwaggerType t) where
   toJSON SwaggerArray   = "array"
@@ -1442,11 +1441,10 @@ referencedParseJSON prefix js@(Object o) = do
         Just suffix -> pure (Reference suffix)
 referencedParseJSON _ _ = fail "referenceParseJSON: not an object"
 
--- FIXME this stuff
-instance FromJSON (Referenced Schema)   where parseJSON = referencedParseJSON "#/definitions/"
-instance FromJSON (Referenced Param)    where parseJSON = referencedParseJSON "#/parameters/"
-instance FromJSON (Referenced Response) where parseJSON = referencedParseJSON "#/responses/"
-instance FromJSON (Referenced RequestBody) where parseJSON = referencedParseJSON "#/!!!!/"
+instance FromJSON (Referenced Schema)   where parseJSON = referencedParseJSON "#/components/schemas/"
+instance FromJSON (Referenced Param)    where parseJSON = referencedParseJSON "#/components/parameters/"
+instance FromJSON (Referenced Response) where parseJSON = referencedParseJSON "#/components/responses/"
+instance FromJSON (Referenced RequestBody) where parseJSON = referencedParseJSON "#/components/requestBodies"
 
 instance FromJSON Xml where
   parseJSON = genericParseJSON (jsonPrefix "xml")

--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -348,7 +348,7 @@ data RequestBody = RequestBody
 
 -- | Each Media Type Object provides schema and examples for the media type identified by its key.
 data MediaTypeObject = MediaTypeObject
-  { _mediaTypeSchema :: Maybe (Referenced Schema)
+  { _mediaTypeObjectSchema :: Maybe (Referenced Schema)
 
 -- TODO
 --  , _mediaTypeExample
@@ -975,6 +975,12 @@ instance Monoid Response where
   mempty = genericMempty
   mappend = (<>)
 
+instance Semigroup MediaTypeObject where
+  (<>) = genericMappend
+instance Monoid MediaTypeObject where
+  mempty = genericMempty
+  mappend = (<>)
+
 instance Semigroup ExternalDocs where
   (<>) = genericMappend
 instance Monoid ExternalDocs where
@@ -1498,7 +1504,7 @@ instance HasSwaggerAesonOptions Response where
 instance HasSwaggerAesonOptions RequestBody where
   swaggerAesonOptions _ = mkSwaggerAesonOptions "requestBody"
 instance HasSwaggerAesonOptions MediaTypeObject where
-  swaggerAesonOptions _ = mkSwaggerAesonOptions "mediaType"
+  swaggerAesonOptions _ = mkSwaggerAesonOptions "mediaTypeObject"
 instance HasSwaggerAesonOptions Responses where
   swaggerAesonOptions _ = mkSwaggerAesonOptions "responses" & saoSubObject ?~ "responses"
 instance HasSwaggerAesonOptions SecurityScheme where

--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -1508,7 +1508,7 @@ instance HasSwaggerAesonOptions SecurityScheme where
 instance HasSwaggerAesonOptions Schema where
   swaggerAesonOptions _ = mkSwaggerAesonOptions "schema" & saoSubObject ?~ "paramSchema"
 instance HasSwaggerAesonOptions Swagger where
-  swaggerAesonOptions _ = mkSwaggerAesonOptions "swagger" & saoAdditionalPairs .~ [("openapi", "3.0")]
+  swaggerAesonOptions _ = mkSwaggerAesonOptions "swagger" & saoAdditionalPairs .~ [("openapi", "3.0.3")]
 
 instance HasSwaggerAesonOptions (ParamSchema ('SwaggerKindNormal t)) where
   swaggerAesonOptions _ = mkSwaggerAesonOptions "paramSchema" & saoSubObject ?~ "items"

--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -603,11 +603,15 @@ data Schema = Schema
   , _schemaDescription :: Maybe Text
   , _schemaRequired :: [ParamName]
 
+  , _schemaNullable :: Maybe Bool
   , _schemaAllOf :: Maybe [Referenced Schema]
+  , _schemaOneOf :: Maybe [Referenced Schema]
+  --, _schemaNot :: Maybe (Referenced Schema) FIXME name clash
+  , _schemaAnyOf :: Maybe [Referenced Schema]
   , _schemaProperties :: InsOrdHashMap Text (Referenced Schema)
   , _schemaAdditionalProperties :: Maybe AdditionalProperties
 
-  , _schemaDiscriminator :: Maybe Text
+  , _schemaDiscriminator :: Maybe Text -- FIXME Discriminator object
   , _schemaReadOnly :: Maybe Bool
   , _schemaXml :: Maybe Xml
   , _schemaExternalDocs :: Maybe ExternalDocs

--- a/src/Data/Swagger/Lens.hs
+++ b/src/Data/Swagger/Lens.hs
@@ -27,6 +27,10 @@ import Data.Text (Text)
 -- * Classy lenses
 
 makeFields ''Swagger
+makeFields ''Components
+makeFields ''Server
+makeFields ''RequestBody
+makeFields ''MediaTypeObject
 makeFields ''Host
 makeFields ''Info
 makeFields ''Contact


### PR DESCRIPTION
Hi,

I've started porting `swagger2` to `openapi3`, I will track my progress here.

I am following the spec at https://swagger.io/specification/, version 3.0.3.

Currently it works for simple cases:

```haskell
λ> (decs, resp) = runDeclare (declareResponse "application/json" (Proxy @Day)) mempty
λ> resps = mempty & responses.at 200 ?~ Inline resp :: Responses
λ> op = mempty & responses .~ resps :: Operation
λ> swag = mempty & components.schemas <>~ decs & paths.at "/day" ?~ pathItem :: Swagger
λ> BSL.putStrLn $ encode swag

{"openapi":"3.0.3","info":{"version":"","title":""},"paths":{"/day":{"get":{"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/Day"}}},"description":""}}}}},"components":{"schemas":{"Day":{"example":"2016-07-22","format":"date","type":"string"}}}}
```

And it renders as expected on Swagger Editor:

![image](https://user-images.githubusercontent.com/275614/85453313-690dd680-b5a4-11ea-960f-651a54946d04.png)

Of course, `servant-swagger` will have to be updated as well... See https://github.com/haskell-servant/servant-swagger/issues/99

Fixes #105.