### PR TITLE
Add 9.0.2 to the CI matrix, complete migration to 9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2"]
         cabal: ["3.6.2.0"]
         os: [ubuntu-latest, macOS-latest]
     name: build and test (cabal)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.4", "8.10.7"]
+        ghc: ["8.6.5", "8.8.4", "8.10.4", "8.10.7", "9.2"]
         cabal: ["3.6.2.0"]
         os: [ubuntu-latest, macOS-latest]
     name: build and test (cabal)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.4", "8.10.7", "9.2"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2"]
         cabal: ["3.6.2.0"]
         os: [ubuntu-latest, macOS-latest]
     name: build and test (cabal)
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1
         with:
-          ghc-version: "8.10.7"
+          ghc-version: "9.0.2"
           enable-stack: true
           stack-version: "latest"
       - run: |

--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -363,7 +364,7 @@ data ParamOtherSchema = ParamOtherSchema
 -- @'SwaggerItemsObject'@ should be used to specify homogenous array @'Schema'@s.
 --
 -- @'SwaggerItemsArray'@ should be used to specify tuple @'Schema'@s.
-data SwaggerItems t where
+data SwaggerItems (t :: SwaggerKind *) where
   SwaggerItemsPrimitive :: Maybe (CollectionFormat k) -> ParamSchema k-> SwaggerItems k
   SwaggerItemsObject    :: Referenced Schema   -> SwaggerItems 'SwaggerKindSchema
   SwaggerItemsArray     :: [Referenced Schema] -> SwaggerItems 'SwaggerKindSchema
@@ -422,7 +423,7 @@ instance Data (SwaggerItems 'SwaggerKindSchema) where
   dataTypeOf _ = swaggerItemsDataType
 
 -- | Type used as a kind to avoid overlapping instances.
-data SwaggerKind t
+data SwaggerKind (t :: *)
     = SwaggerKindNormal t
     | SwaggerKindParamOtherSchema
     | SwaggerKindSchema
@@ -437,7 +438,7 @@ type instance SwaggerKindType ('SwaggerKindNormal t) = t
 type instance SwaggerKindType 'SwaggerKindSchema = Schema
 type instance SwaggerKindType 'SwaggerKindParamOtherSchema = ParamOtherSchema
 
-data SwaggerType t where
+data SwaggerType (t :: SwaggerKind *) where
   SwaggerString   :: SwaggerType t
   SwaggerNumber   :: SwaggerType t
   SwaggerInteger  :: SwaggerType t
@@ -508,7 +509,7 @@ data ParamLocation
 type Format = Text
 
 -- | Determines the format of the array.
-data CollectionFormat t where
+data CollectionFormat (t :: SwaggerKind *) where
   -- Comma separated values: @foo,bar@.
   CollectionCSV :: CollectionFormat t
   -- Space separated values: @foo bar@.


### PR DESCRIPTION
- Add `9.0.2` to the CI matrix.
- Make `9.0.2` as default latest.
- Migrate `Data.Swagger.Internal` to 9.2 via enabling `PolyKinds`.