### PR TITLE
Remove auto-derivable Typeable instances

### DIFF
--- a/src/Data/Swagger/Internal.hs
+++ b/src/Data/Swagger/Internal.hs
@@ -371,7 +371,6 @@ data SwaggerItems t where
 
 deriving instance Eq (SwaggerItems t)
 deriving instance Show (SwaggerItems t)
---deriving instance Typeable (SwaggerItems t)
 
 swaggerItemsPrimitiveConstr :: Constr
 swaggerItemsPrimitiveConstr = mkConstr swaggerItemsDataType "SwaggerItemsPrimitive" [] Prefix
@@ -426,11 +425,6 @@ data SwaggerKind t
     = SwaggerKindNormal t
     | SwaggerKindParamOtherSchema
     | SwaggerKindSchema
-    deriving (Typeable)
-
-deriving instance Typeable 'SwaggerKindNormal
-deriving instance Typeable 'SwaggerKindParamOtherSchema
-deriving instance Typeable 'SwaggerKindSchema
 
 type family SwaggerKindType (k :: SwaggerKind *) :: *
 type instance SwaggerKindType ('SwaggerKindNormal t) = t


### PR DESCRIPTION
This fixes compilation on GHC 9.2. Typeable has been auto-derivable for many years now, so even the oldest GHC version in CI doesn't need these statements.

The fact that it breaks compilation on GHC 9.2 may be a bug, I will investigate this. But meanwhile, we can just remove this.

Passes the test suite on GHC 8.6 and GHC 9.2.

The test failure on MacOS seems unrelated.

Thanks to awpr on Libera.Chat.