### PR TITLE
Allow text-2.0

### DIFF
--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -322,8 +323,13 @@ passwordSchema = mempty
 --
 -- >>> data Person = Person { name :: String, age :: Int } deriving (Generic)
 -- >>> instance ToJSON Person
+#if MIN_VERSION_text(2,0,0)
+-- >>> encode $ sketchSchema (Person "Jack" 25)
+-- "{\"required\":[\"age\",\"name\"],\"properties\":{\"name\":{\"type\":\"string\"},\"age\":{\"type\":\"number\"}},\"example\":{\"age\":25,\"name\":\"Jack\"},\"type\":\"object\"}"
+#else
 -- >>> encode $ sketchSchema (Person "Jack" 25)
 -- "{\"required\":[\"name\",\"age\"],\"properties\":{\"name\":{\"type\":\"string\"},\"age\":{\"type\":\"number\"}},\"example\":{\"age\":25,\"name\":\"Jack\"},\"type\":\"object\"}"
+#endif
 sketchSchema :: ToJSON a => a -> Schema
 sketchSchema = sketch . toJSON
   where
@@ -366,8 +372,13 @@ sketchSchema = sketch . toJSON
 --
 -- >>> data Person = Person { name :: String, age :: Int } deriving (Generic)
 -- >>> instance ToJSON Person
+#if MIN_VERSION_text(2,0,0)
+-- >>> encode $ sketchStrictSchema (Person "Jack" 25)
+-- "{\"required\":[\"age\",\"name\"],\"properties\":{\"name\":{\"enum\":[\"Jack\"],\"maxLength\":4,\"minLength\":4,\"pattern\":\"Jack\",\"type\":\"string\"},\"age\":{\"enum\":[25],\"maximum\":25,\"minimum\":25,\"multipleOf\":25,\"type\":\"number\"}},\"maxProperties\":2,\"minProperties\":2,\"enum\":[{\"age\":25,\"name\":\"Jack\"}],\"type\":\"object\"}"
+#else
 -- >>> encode $ sketchStrictSchema (Person "Jack" 25)
 -- "{\"required\":[\"name\",\"age\"],\"properties\":{\"name\":{\"enum\":[\"Jack\"],\"maxLength\":4,\"minLength\":4,\"pattern\":\"Jack\",\"type\":\"string\"},\"age\":{\"enum\":[25],\"maximum\":25,\"minimum\":25,\"multipleOf\":25,\"type\":\"number\"}},\"maxProperties\":2,\"minProperties\":2,\"enum\":[{\"age\":25,\"name\":\"Jack\"}],\"type\":\"object\"}"
+#endif
 sketchStrictSchema :: ToJSON a => a -> Schema
 sketchStrictSchema = go . toJSON
   where

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -68,7 +68,7 @@ library
 
   build-depends:
       mtl              >=2.2.2   && <2.3
-    , text             >=1.2.3.0 && <1.3
+    , text             >=1.2.3.0 && <2.1
 
   -- other dependencies
   build-depends:


### PR DESCRIPTION
Sadly the doctests fail because the ordering of the required keys changes with text-2.0. I don't know the source so well, so I havn't attempted fixing this.

Fails:

    cabal test --constraint='text>=2' -w ghc-9.0.2

Passes:

    cabal test --constraint='text<2' -w ghc-9.0.2

Thanks for your work!
