### PR TITLE
Use "date-time" format for UTCTime

### DIFF
--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -501,9 +501,9 @@ instance ToSchema NominalDiffTime where
 
 -- |
 -- >>> toSchema (Proxy :: Proxy UTCTime) ^. format
--- Just "yyyy-mm-ddThh:MM:ssZ"
+-- Just "date-time"
 instance ToSchema UTCTime where
-  declareNamedSchema _ = pure $ named "UTCTime" $ timeSchema "yyyy-mm-ddThh:MM:ssZ"
+  declareNamedSchema _ = pure $ named "UTCTime" $ timeSchema "date-time"
     & example ?~ toJSON (UTCTime (fromGregorian 2016 7 22) 0)
 
 instance ToSchema T.Text where declareNamedSchema = plain . paramSchemaToSchema


### PR DESCRIPTION
The current format definition for UTCTime makes swagger-codegen-cli use (at least with javascript code generation) String as the data type. Using `date-time` (as defined in https://swagger.io/docs/specification/data-models/data-types/) instead makes it use Date instead.