### PR TITLE
Allow newer dependencies

### DIFF
--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -74,7 +74,7 @@ library
   -- other dependencies
   build-depends:
       base-compat-batteries     >=0.11.1   && <0.13
-    , aeson                     >=2.0.0.0  && <2.1
+    , aeson                     >=2.0.0.0  && <2.2
     , aeson-pretty              >=0.8.7    && <0.9
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint
     , cookie                    >=0.4.3    && <0.5
@@ -82,14 +82,14 @@ library
     , hashable                  >=1.2.7.0  && <1.5
     , http-media                >=0.8.0.0  && <0.9
     , insert-ordered-containers >=0.2.3    && <0.3
-    , lens                      >=4.16.1   && <5.2
+    , lens                      >=4.16.1   && <5.3
     , network                   >=2.6.3.5  && <3.2
     , optics-core               >=0.2      && <0.5
     , optics-th                 >=0.2      && <0.5
     , scientific                >=0.3.6.2  && <0.4
     , unordered-containers      >=0.2.9.0  && <0.3
     , uuid-types                >=1.0.3    && <1.1
-    , vector                    >=0.12.0.1 && <0.13
+    , vector                    >=0.12.0.1 && <0.14
     , QuickCheck                >=2.10.1   && <2.15
 
   default-language:    Haskell2010
@@ -121,7 +121,7 @@ test-suite spec
 
   -- test-suite only dependencies
   build-depends:
-      hspec                >=2.5.5   && <2.9
+      hspec                >=2.5.5   && <2.11
     , HUnit                >=1.6.0.0 && <1.7
     , quickcheck-instances >=0.3.19  && <0.14
     , utf8-string          >=1.0.1.1 && <1.1


### PR DESCRIPTION
Includes #238. Fixes

* commercialhaskell/stackage#6678
* https://github.com/commercialhaskell/stackage/issues/6615
* https://github.com/commercialhaskell/stackage/issues/6624
* https://github.com/commercialhaskell/stackage/issues/6573

Tested using

    cabal test -w ghc-9.2.4 --enable-tests --constraint='aeson>=2.1' --constraint='lens>=5.2' --constraint='vector>=0.13' --constraint='hspec>=2.10'