### PR TITLE
Bump base and template-haskell bounds (GHC 9.4 support)

### DIFF
--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -60,10 +60,10 @@ library
 
   -- GHC boot libraries
   build-depends:
-      base             >=4.9       && <4.17
+      base             >=4.9       && <4.18
     , bytestring       >=0.10.8.1  && <0.12
     , containers       >=0.5.7.1   && <0.7
-    , template-haskell >=2.11.1.0  && <2.19
+    , template-haskell >=2.11.1.0  && <2.20
     , time             >=1.6.0.1   && <1.14
     , transformers     >=0.5.2.0   && <0.7
 


### PR DESCRIPTION
I've checked that the tests still pass.