### PR TITLE
Support ghc-9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.3"]
-        cabal: ["3.6.2.0"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.7", "9.4.4", "9.6.1"]
+        cabal: ["3.10.1.0"]
         os: [ubuntu-latest, macOS-latest]
     name: build and test (cabal)
     steps:
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1
         with:
-          ghc-version: "9.2.3"
+          ghc-version: "9.2.7"
           enable-stack: true
           stack-version: "latest"
       - run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,11 @@
 packages: .
 tests: true
+
+if(impl(ghc >= 9.6.1) && impl(ghc < 9.7))
+  allow-newer: insert-ordered-containers:base
+  allow-newer: insert-ordered-containers:transformers
+  allow-newer: insert-ordered-containers:semigroupoids
+  allow-newer: generics-sop:base
+  allow-newer: generics-sop:ghc-prim
+  allow-newer: generics-sop:template-haskell
+  allow-newer: sop-core:base

--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -124,12 +124,12 @@ import Data.Swagger.Internal
 -- $setup
 -- >>> import Control.Lens
 -- >>> import Data.Aeson
+-- >>> import qualified Data.HashMap.Strict.InsOrd as IOHM
 -- >>> import Data.Monoid
 -- >>> import Data.Proxy
 -- >>> import GHC.Generics
 -- >>> :set -XDeriveGeneric
 -- >>> :set -XOverloadedStrings
--- >>> :set -XOverloadedLists
 -- >>> :set -fno-warn-missing-methods
 
 -- $howto
@@ -185,8 +185,8 @@ import Data.Swagger.Internal
 --
 -- >>> :{
 -- encode $ (mempty :: Swagger)
---   & definitions .~ [ ("User", mempty & type_ ?~ SwaggerString) ]
---   & paths .~
+--   & definitions .~ IOHM.fromList [ ("User", mempty & type_ ?~ SwaggerString) ]
+--   & paths .~ IOHM.fromList
 --     [ ("/user", mempty & get ?~ (mempty
 --         & produces ?~ MimeList ["application/json"]
 --         & at 200 ?~ ("OK" & _Inline.schema ?~ Ref (Reference "User"))
@@ -297,7 +297,6 @@ import Data.Swagger.Internal
 -- >>> data BadMixedType = ChoiceBool Bool | JustTag deriving Generic
 -- >>> instance ToSchema BadMixedType
 -- ...
--- ... error:
 -- ... • Cannot derive Generic-based Swagger Schema for BadMixedType
 -- ...   BadMixedType is a mixed sum type (has both unit and non-unit constructors).
 -- ...   Swagger does not have a good representation for these types.

--- a/src/Data/Swagger/Operation.hs
+++ b/src/Data/Swagger/Operation.hs
@@ -57,13 +57,14 @@ import qualified Data.HashSet.InsOrd as InsOrdHS
 
 -- $setup
 -- >>> import Data.Aeson
+-- >>> import qualified Data.HashMap.Strict.InsOrd as IOHM
 -- >>> import Data.Proxy
 -- >>> import Data.Time
 
 -- | Prepend path piece to all operations of the spec.
 -- Leading and trailing slashes are trimmed/added automatically.
 --
--- >>> let api = (mempty :: Swagger) & paths .~ [("/info", mempty)]
+-- >>> let api = (mempty :: Swagger) & paths .~ IOHM.fromList [("/info", mempty)]
 -- >>> encode $ prependPath "user/{user_id}" api ^. paths
 -- "{\"/user/{user_id}/info\":{}}"
 prependPath :: FilePath -> Swagger -> Swagger
@@ -84,8 +85,8 @@ allOperations = paths.traverse.template
 -- by both path and method.
 --
 -- >>> let ok = (mempty :: Operation) & at 200 ?~ "OK"
--- >>> let api = (mempty :: Swagger) & paths .~ [("/user", mempty & get ?~ ok & post ?~ ok)]
--- >>> let sub = (mempty :: Swagger) & paths .~ [("/user", mempty & get ?~ mempty)]
+-- >>> let api = (mempty :: Swagger) & paths .~ IOHM.fromList [("/user", mempty & get ?~ ok & post ?~ ok)]
+-- >>> let sub = (mempty :: Swagger) & paths .~ IOHM.fromList [("/user", mempty & get ?~ mempty)]
 -- >>> encode api
 -- "{\"swagger\":\"2.0\",\"info\":{\"title\":\"\",\"version\":\"\"},\"paths\":{\"/user\":{\"get\":{\"responses\":{\"200\":{\"description\":\"OK\"}}},\"post\":{\"responses\":{\"200\":{\"description\":\"OK\"}}}}}}"
 -- >>> encode $ api & operationsOf sub . at 404 ?~ "Not found"
@@ -150,7 +151,7 @@ declareResponse proxy = do
 --
 -- Example:
 --
--- >>> let api = (mempty :: Swagger) & paths .~ [("/user", mempty & get ?~ mempty)]
+-- >>> let api = (mempty :: Swagger) & paths .~ IOHM.fromList [("/user", mempty & get ?~ mempty)]
 -- >>> let res = declareResponse (Proxy :: Proxy Day)
 -- >>> encode $ api & setResponse 200 res
 -- "{\"swagger\":\"2.0\",\"info\":{\"title\":\"\",\"version\":\"\"},\"paths\":{\"/user\":{\"get\":{\"responses\":{\"200\":{\"description\":\"\",\"schema\":{\"$ref\":\"#/definitions/Day\"}}}}}},\"definitions\":{\"Day\":{\"example\":\"2016-07-22\",\"format\":\"date\",\"type\":\"string\"}}}"

--- a/src/Data/Swagger/Optics.hs
+++ b/src/Data/Swagger/Optics.hs
@@ -15,6 +15,7 @@
 -- library.
 --
 -- >>> import Data.Aeson
+-- >>> import qualified Data.HashMap.Strict.InsOrd as IOHM
 -- >>> import Optics.Core
 -- >>> :set -XOverloadedLabels
 --
@@ -22,8 +23,8 @@
 --
 -- >>> :{
 -- encode $ (mempty :: Swagger)
---   & #definitions .~ [ ("User", mempty & #type ?~ SwaggerString) ]
---   & #paths .~
+--   & #definitions .~ IOHM.fromList [ ("User", mempty & #type ?~ SwaggerString) ]
+--   & #paths .~ IOHM.fromList
 --     [ ("/user", mempty & #get ?~ (mempty
 --         & #produces ?~ MimeList ["application/json"]
 --         & at 200 ?~ ("OK" & #_Inline % #schema ?~ Ref (Reference "User"))

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -60,10 +60,10 @@ library
 
   -- GHC boot libraries
   build-depends:
-      base             >=4.9       && <4.18
+      base             >=4.9       && <4.19
     , bytestring       >=0.10.8.1  && <0.12
     , containers       >=0.5.7.1   && <0.7
-    , template-haskell >=2.11.1.0  && <2.20
+    , template-haskell >=2.11.1.0  && <2.21
     , time             >=1.6.0.1   && <1.14
     , transformers     >=0.5.2.0   && <0.7
 
@@ -73,7 +73,7 @@ library
 
   -- other dependencies
   build-depends:
-      base-compat-batteries     >=0.11.1   && <0.13
+      base-compat-batteries     >=0.11.1   && <0.14
     , aeson                     >=2.0.0.0  && <2.2
     , aeson-pretty              >=0.8.7    && <0.9
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint


### PR DESCRIPTION
doctest v0.21.1 is the [only version that supports GHC 9.6](https://hackage.haskell.org/package/doctest-0.21.1/changelog), but doctest v0.21.1 isn't
working well with OverloadedLists: https://github.com/sol/doctest/issues/389

So I just removed the use of OverloadedLists.

Also, GHC 9.6 has numbered errors that are printed after "error:". So to make
the error still match, I just opted for removing this line from a doctest
instead of introducing an `ifdef`.

This contains allow-newers that could be removed when these changes are on Hackage:
* well-typed/generics-sop/pull/161
* phadej/insert-ordered-containers/pull/46
* phadej/insert-ordered-containers/issues/50