### PR TITLE
Build with GHC 9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.4", "9.8.1"]
         cabal: ["3.10.2.0"]
         os: [ubuntu-latest, macOS-latest]
+      fail-fast: false
     name: build and test (cabal)
     steps:
       - uses: actions/checkout@v2
@@ -30,6 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.7", "9.4.4", "9.6.1"]
-        cabal: ["3.10.1.0"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.4", "9.8.1"]
+        cabal: ["3.10.2.0"]
         os: [ubuntu-latest, macOS-latest]
     name: build and test (cabal)
     steps:
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1
         with:
-          ghc-version: "9.2.7"
+          ghc-version: "9.2.8"
           enable-stack: true
           stack-version: "latest"
       - run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,2 @@
 packages: .
 tests: true
-
-if(impl(ghc >= 9.6.1) && impl(ghc < 9.7))
-  allow-newer: insert-ordered-containers:base
-  allow-newer: insert-ordered-containers:transformers
-  allow-newer: insert-ordered-containers:semigroupoids
-  allow-newer: generics-sop:base
-  allow-newer: generics-sop:ghc-prim
-  allow-newer: generics-sop:template-haskell
-  allow-newer: sop-core:base

--- a/src/Data/Swagger/Internal/Schema.hs
+++ b/src/Data/Swagger/Internal/Schema.hs
@@ -40,6 +40,7 @@ import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import Data.Int
 import Data.IntSet (IntSet)
 import Data.IntMap (IntMap)
+import qualified Data.List as L
 import Data.List.NonEmpty.Compat (NonEmpty)
 import Data.Map (Map)
 import Data.Proxy
@@ -686,6 +687,7 @@ genericNameSchema opts _ = NamedSchema (gdatatypeSchemaName opts (Proxy :: Proxy
 
 gdatatypeSchemaName :: forall d. Datatype d => SchemaOptions -> Proxy d -> Maybe T.Text
 gdatatypeSchemaName opts _ = case orig of
+  dtn   | L.isPrefixOf "Tuple" dtn -> Nothing -- special case for new TupleNNN types in GHC 9.8
   (c:_) | isAlpha c && isUpper c -> Just (T.pack name)
   _ -> Nothing
   where

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -23,17 +23,17 @@ extra-source-files:
   , CHANGELOG.md
   , examples/*.hs
 tested-with:
-  GHC ==8.4.4
-   || ==8.6.5
+  GHC ==8.6.5
    || ==8.8.4
-   || ==8.10.4
    || ==8.10.7
    || ==9.0.2
-   || ==9.2.3
+   || ==9.2.8
+   || ==9.6.4
+   || ==9.8.1
 
 custom-setup
   setup-depends:
-                base < 4.19
+                base < 4.20
               , Cabal < 3.11
               , cabal-doctest >=1.0.6 && <1.1
 
@@ -62,21 +62,21 @@ library
 
   -- GHC boot libraries
   build-depends:
-      base             >=4.9       && <4.19
-    , bytestring       >=0.10.8.1  && <0.12
+      base             >=4.9       && <4.20
+    , bytestring       >=0.10.8.1  && <0.13
     , containers       >=0.5.7.1   && <0.7
-    , template-haskell >=2.11.1.0  && <2.21
+    , template-haskell >=2.11.1.0  && <2.22
     , time             >=1.6.0.1   && <1.14
     , transformers     >=0.5.2.0   && <0.7
 
   build-depends:
       mtl              >=2.2.2   && <2.4
-    , text             >=1.2.3.0 && <2.1
+    , text             >=1.2.3.0 && <2.2
 
   -- other dependencies
   build-depends:
       base-compat-batteries     >=0.11.1   && <0.14
-    , aeson                     >=2.0.0.0  && <2.2
+    , aeson                     >=2.0.0.0  && <2.3
     , aeson-pretty              >=0.8.7    && <0.9
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint
     , cookie                    >=0.4.3    && <0.5
@@ -123,7 +123,7 @@ test-suite spec
 
   -- test-suite only dependencies
   build-depends:
-      hspec                >=2.5.5   && <2.11
+      hspec                >=2.5.5   && <2.12
     , HUnit                >=1.6.0.0 && <1.7
     , quickcheck-instances >=0.3.19  && <0.14
     , utf8-string          >=1.0.1.1 && <1.1


### PR DESCRIPTION
The first commit solves #248. A bit hacky, but maybe somebody else comes up with a better idea?

The second commit builds with GHC 9.8.

The third commit removes `allow-newers` for GHC 9.6 - it seems to build without them fine by now.

The last commit just allow all CI jobs to keep running while one of them fails - helpful to find out that maybe more than one build is failing.