### PR TITLE
Bump deps and fix doctest for GHC 9.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.4", "9.8.1"]
-        cabal: ["3.10.2.0"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.5", "9.8.2", "9.10.1"]
+        cabal: ["3.12.1.0"]
         os: [ubuntu-latest, macOS-latest]
       fail-fast: false
     name: build and test (cabal)

--- a/src/Data/Swagger.hs
+++ b/src/Data/Swagger.hs
@@ -304,7 +304,6 @@ import Data.Swagger.Internal
 -- ...   that matches aeson's Generic-based toJSON,
 -- ...   but that's not supported by some Swagger tools.
 -- ...
--- ... In the instance declaration for ‘ToSchema BadMixedType’
 --
 -- We can use 'genericDeclareNamedSchemaUnrestricted' to try our best to represent this type as a Swagger Schema and match 'ToJSON':
 --

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -34,7 +34,7 @@ tested-with:
 custom-setup
   setup-depends:
                 base < 4.21
-              , Cabal < 3.11
+              , Cabal < 3.13
               , cabal-doctest >=1.0.6 && <1.1
 
 library

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -81,7 +81,7 @@ library
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint
     , cookie                    >=0.4.3    && <0.6
     , generics-sop              >=0.5.1.0  && <0.6
-    , hashable                  >=1.2.7.0  && <1.5
+    , hashable                  >=1.2.7.0  && <1.6
     , http-media                >=0.8.0.0  && <0.9
     , insert-ordered-containers >=0.2.3    && <0.3
     , lens                      >=4.16.1   && <5.4

--- a/swagger2.cabal
+++ b/swagger2.cabal
@@ -33,7 +33,7 @@ tested-with:
 
 custom-setup
   setup-depends:
-                base < 4.20
+                base < 4.21
               , Cabal < 3.11
               , cabal-doctest >=1.0.6 && <1.1
 
@@ -62,10 +62,10 @@ library
 
   -- GHC boot libraries
   build-depends:
-      base             >=4.9       && <4.20
+      base             >=4.9       && <4.21
     , bytestring       >=0.10.8.1  && <0.13
-    , containers       >=0.5.7.1   && <0.7
-    , template-haskell >=2.11.1.0  && <2.22
+    , containers       >=0.5.7.1   && <0.8
+    , template-haskell >=2.11.1.0  && <2.23
     , time             >=1.6.0.1   && <1.14
     , transformers     >=0.5.2.0   && <0.7
 
@@ -75,24 +75,24 @@ library
 
   -- other dependencies
   build-depends:
-      base-compat-batteries     >=0.11.1   && <0.14
+      base-compat-batteries     >=0.11.1   && <0.15
     , aeson                     >=2.0.0.0  && <2.3
     , aeson-pretty              >=0.8.7    && <0.9
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint
-    , cookie                    >=0.4.3    && <0.5
+    , cookie                    >=0.4.3    && <0.6
     , generics-sop              >=0.5.1.0  && <0.6
     , hashable                  >=1.2.7.0  && <1.5
     , http-media                >=0.8.0.0  && <0.9
     , insert-ordered-containers >=0.2.3    && <0.3
-    , lens                      >=4.16.1   && <5.3
-    , network                   >=2.6.3.5  && <3.2
+    , lens                      >=4.16.1   && <5.4
+    , network                   >=2.6.3.5  && <3.3
     , optics-core               >=0.2      && <0.5
     , optics-th                 >=0.2      && <0.5
     , scientific                >=0.3.6.2  && <0.4
     , unordered-containers      >=0.2.9.0  && <0.3
     , uuid-types                >=1.0.3    && <1.1
     , vector                    >=0.12.0.1 && <0.14
-    , QuickCheck                >=2.10.1   && <2.15
+    , QuickCheck                >=2.10.1   && <2.16
 
   default-language:    Haskell2010
 


### PR DESCRIPTION
Fix #254

Addresses:

* https://github.com/commercialhaskell/stackage/issues/7335                     
* https://github.com/commercialhaskell/stackage/issues/7381                     
* https://github.com/commercialhaskell/stackage/issues/7391                     
* https://github.com/commercialhaskell/stackage/issues/7399                     
* https://github.com/commercialhaskell/stackage/issues/7403                     
* https://github.com/commercialhaskell/stackage/issues/7408                     
* https://github.com/commercialhaskell/stackage/issues/7418                     
* https://github.com/commercialhaskell/stackage/issues/7476

Tested using:

    cabal test -w ghc-9.10.1 -c 'lens>=5.3' -c 'network>=3.2' -c 'base-compat>=0.14' \
                             -c 'QuickCheck>=2.15' -c 'cookie>=0.5' -c 'hashable>=1.5' \
    --allow-newer=unordered-containers:hashable,lens:hashable,these:hashable,strict:hashable,insert-ordered-containers:hashable,optics-extra:hashable,aeson:hashable,witherable:hashable,semialign:hashable,quickcheck-instances:hashable